### PR TITLE
Initial openapi spec copied from mario

### DIFF
--- a/docs/architecture-decisions/0003-follow-twelve-factor-methodology.md
+++ b/docs/architecture-decisions/0003-follow-twelve-factor-methodology.md
@@ -1,0 +1,27 @@
+# 3. Follow Twelve Factor methodology
+
+Date: 2018-10-16
+
+## Status
+
+Accepted
+
+## Context
+
+Designing modern scalable cloud based applications requires intentionally
+designing the architecture to take advantage of the cloud.
+
+One leading way to do that is
+[The Twelve Factor](https://12factor.net) methodology.
+
+## Decision
+
+We will follow Twelve Factor methodology.
+
+## Consequences
+
+Our application will be deployable in the cloud in a scalable efficient manner.
+
+We will leverage services for some aspects of applications that
+previously would have relied on a Virtual Machine, such as storage for files
+and logs.

--- a/docs/architecture-decisions/0004-use-openapi-specification.md
+++ b/docs/architecture-decisions/0004-use-openapi-specification.md
@@ -1,0 +1,19 @@
+# 4. Use OpenAPI Specification
+
+Date: 2018-10-16
+
+## Status
+
+Accepted
+
+## Context
+
+By choosing an API documentation standard we make it easier to auto generate developer documentation. There are two existing standards used to document REST APIs--RAML and OpenAPI Specification (OAS). Both seem capable of doing the job. The main difference seems to be that RAML is focused on defining data models while OpenAPI is focused on the nuts and bolts of the API. If we were supporting several APIs, RAML might be more useful for defining reusable types across systems. In this case OAS seems more suited to our task.
+
+## Decision
+
+Use OpenAPI specification to document the API.
+
+## Consequences
+
+Given that Mulesoft uses RAML and Swagger uses OAS, this means we'd be probably be using Swagger as a documentation platform (if we choose to do so). There are tools to convert between RAML and OAS, though, so if we decide we would rather use RAML later it should not be too difficult to switch.

--- a/openapi.yml
+++ b/openapi.yml
@@ -1,0 +1,179 @@
+openapi: 3.0.1
+info:
+  version: 0.0.2
+  title: MIT Libraries Discovery API
+paths:
+  /search:
+    get:
+      responses:
+        '200':
+          description: A list of search results
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Results'
+      parameters:
+        - name: q
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+  /record/{id}:
+    get:
+      responses:
+        '200':
+          description: A single record
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FullRecord'
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+components:
+  securitySchemes:
+    api_key:
+      type: apiKey
+      name: api_key
+      in: query
+  schemas:
+    Holding:
+      description: location holdings information
+      type: object
+      properties:
+        location:
+          type: string
+        call_number:
+          type: string
+        status:
+          type: string
+    Identifiers:
+      description: standardized identifiers
+      type: object
+      properties:
+        isbns:
+          type: array
+          items:
+            type: string
+        issns:
+          type: array
+          items:
+            type: string
+        doi:
+          type: string
+    Link:
+      description: a url related to this item
+      type: object
+      properties:
+        text:
+          type: string
+        url:
+          type: string
+          format: uri
+        restrictions:
+          type: string
+        kind:
+          description: what kind of link this is, such as full_text, restricted_full_text, sfx, unknown
+          type: string
+    Record:
+      description: An abbreviated representation of a record
+      type: object
+      required:
+        - id
+        - title
+      properties:
+        id:
+          type: string
+        content_type:
+            description: High level categorization of the type of content, such as text, still image, audio, etc.
+            type: string
+        format:
+            description: High level categorization of the content format, such as online resource, CD, book, etc.
+            type: string
+        source_link:
+          type: string
+          format: uri
+        realtime_holdings_link:
+          type: string
+          format: uri
+        sfx_link:
+          type: string
+          format: uri
+        year:
+          type: string
+        title:
+          type: string
+        full_text_links:
+          type: array
+          items:
+            $ref: '#/components/schemas/Link'
+        authors:
+          type: array
+          items:
+            type: string
+        subjects:
+          type: array
+          items:
+            type: string
+        thumbnail:
+          type: string
+          format: uri
+        summary_holdings:
+          type: array
+          items:
+            $ref: '#/components/schemas/Holding'
+        source:
+          type: string
+        full_record_link:
+          description: link to the full record in this API
+          type: string
+          format: uri
+        citation:
+          type: string
+    FullRecord:
+      description: A full representation of a record
+      allOf:
+        - $ref: '#/components/schemas/Record'
+        - $ref: '#/components/schemas/Identifiers'
+        - type: object
+          properties:
+            available:
+              type: boolean
+            uniform_title:
+              type: string
+            alternate_title:
+              type: string
+            summary:
+              type: string
+            imprint:
+              type: string
+            language:
+              type: string
+            physical_description:
+              type: string
+            abstract:
+              type: string
+            content_notes:
+              type: string
+            notes:
+              type: string
+            edition:
+              type: string
+            publication_frequency:
+              type: string
+
+    Results:
+      type: array
+      items:
+        $ref: '#/components/schemas/Record'
+security:
+  - api_key: []


### PR DESCRIPTION
#### What does this PR do?

- copies OpenApi spec from Mario to this repo as this repo will be where we implement that work
- adds an ADR for `Follow Twelve Factor methodology`
- adds an ADR for `Use OpenAPI Specification ` 

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO