### PR TITLE
Updates openapi spec to match current implementation

### DIFF
--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -14,7 +14,7 @@ module Api
         @results = Timdex::EsClient.get(index: ENV['ELASTICSEARCH_INDEX'],
                                         id: params[:id])
       rescue Elasticsearch::Transport::Transport::Errors::NotFound
-        render json: 'record not found', status: :not_found
+        render json: 'record not found'.to_json, status: :not_found
       end
 
       def ping

--- a/app/views/api/v1/search/_base.json.jbuilder
+++ b/app/views/api/v1/search/_base.json.jbuilder
@@ -7,8 +7,7 @@ json.format result['format']
 json.realtime_holdings_link 'Not Yet Implemented'
 json.publication_date result['publication_date']
 json.title result['title']
-json.links ['Not Yet Implemented']
+json.links result['links']
 json.authors result['creators']
 json.subjects result['subjects']
-json.thumbnail 'Not Yet Implemented'
 json.summary_holdings ['Not Yet Implemented']

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,61 @@
+<!-- HTML for static distribution bundle build -->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>TIMDEX API Documentationd</title>
+    <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist@3.19.5/swagger-ui.css" >
+    <link rel="icon" type="image/png" href="./favicon-32x32.png" sizes="32x32" />
+    <link rel="icon" type="image/png" href="./favicon-16x16.png" sizes="16x16" />
+    <style>
+      html
+      {
+        box-sizing: border-box;
+        overflow: -moz-scrollbars-vertical;
+        overflow-y: scroll;
+      }
+
+      *,
+      *:before,
+      *:after
+      {
+        box-sizing: inherit;
+      }
+
+      body
+      {
+        margin:0;
+        background: #fafafa;
+      }
+    </style>
+
+    <script src="https://unpkg.com/swagger-ui-dist@3/swagger-ui-bundle.js"></script>
+  </head>
+
+  <body>
+    <div id="swagger-ui"></div>
+
+    <script>
+
+    window.onload = function() {
+      // Begin Swagger UI call region
+      const ui = SwaggerUIBundle({
+        url: "../openapi.yml",
+        dom_id: '#swagger-ui',
+        deepLinking: true,
+        presets: [
+          SwaggerUIBundle.presets.apis,
+          // SwaggerUIStandalonePreset
+        ],
+        plugins: [
+          SwaggerUIBundle.plugins.DownloadUrl
+        ],
+        // layout: "StandaloneLayout"
+      })
+      // End Swagger UI call region
+
+      window.ui = ui
+    }
+  </script>
+  </body>
+</html>

--- a/openapi.yml
+++ b/openapi.yml
@@ -3,27 +3,46 @@ info:
   version: 0.0.3
   title: MIT Libraries Discovery API
 servers:
-  - url: 'https://timdex-prod.herokuapp.com'
-  - url: 'http://localhost:3000/api/v1'
+  - url: 'https://timdex-prod.herokuapp.com/api/v1'
+tags:
+  - name: Authenticate
+    description: Authenticate with username / password to retrieve JWT Token
+    externalDocs:
+      description: Register for an account
+      url: 'https://timdex-prod.herokuapp.com'
+  - name: Search
+    description: Query TIMDEX to identify records of interest.
+  - name: Retrieve
+  - name: Status
 paths:
   /ping:
     get:
+      operationId: ping
+      tags:
+        - Status
       responses:
         '200':
           description: OK
   /auth:
     get:
+      tags:
+        - Authenticate
+      operationId: authenticate
       responses:
         '200':
           description: JWT token
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Token'
+                type: string
+                example: "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxMjM0NTY3ODkwLCJleHAiOjEwMDI3MjY3ODB9.EHQe7SfsmBQiow_x_NtPoXFXZM29oVxBo3DqDYURJ68"
       security:
         - basicAuth: []
   /search:
     get:
+      tags:
+        - Search
+      operationId: search
       responses:
         '200':
           description: A list of search results
@@ -31,6 +50,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Results'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
       parameters:
         - name: q
           in: query
@@ -47,6 +68,9 @@ paths:
         - jwtAuth: []
   '/record/{id}':
     get:
+      tags:
+        - Retrieve
+      operationId: getByRecordID
       responses:
         '200':
           description: A single record
@@ -54,6 +78,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FullRecord'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          description: A record with that supplied ID was not found.
       parameters:
         - name: id
           in: path
@@ -71,19 +99,22 @@ components:
       type: http
       scheme: bearer
       bearerFormat: JWT
+  responses:
+    UnauthorizedError:
+      description: Access token is missing or invalid
   schemas:
-    Token:
-      type: string
     Holding:
-      description: location holdings information
+      description: Summary location holdings information. Call `realtime_holdings_link` for recent information if present.
       type: object
       properties:
         location:
           type: string
         call_number:
           type: string
-        status:
+        summary:
           type: string
+        notes:
+            type: string
     Identifiers:
       description: standardized identifiers
       type: object
@@ -123,6 +154,10 @@ components:
       properties:
         id:
           type: string
+        full_record_link:
+          description: link to the full record in this API
+          type: string
+          format: uri
         content_type:
           description: >-
             High level categorization of the type of content, such as text,
@@ -139,14 +174,11 @@ components:
         realtime_holdings_link:
           type: string
           format: uri
-        sfx_link:
-          type: string
-          format: uri
-        year:
+        publication_date:
           type: string
         title:
           type: string
-        full_text_links:
+        links:
           type: array
           items:
             $ref: '#/components/schemas/Link'
@@ -158,20 +190,11 @@ components:
           type: array
           items:
             type: string
-        thumbnail:
-          type: string
-          format: uri
         summary_holdings:
           type: array
           items:
             $ref: '#/components/schemas/Holding'
         source:
-          type: string
-        full_record_link:
-          description: link to the full record in this API
-          type: string
-          format: uri
-        citation:
           type: string
     FullRecord:
       description: A full representation of a record
@@ -182,29 +205,43 @@ components:
           properties:
             available:
               type: boolean
-            uniform_title:
-              type: string
             alternate_title:
-              type: string
+              type: array
+              items:
+                type: string
+            country_of_publication:
+                type: string
             summary:
               type: string
             imprint:
               type: string
-            language:
-              type: string
+            languages:
+              type: array
+              items:
+                type: string
+            call_numbers:
+              type: array
+              items:
+                type: string
             physical_description:
               type: string
             abstract:
               type: string
-            content_notes:
-              type: string
             notes:
-              type: string
+              type: array
+              items:
+                type: string
             edition:
               type: string
             publication_frequency:
               type: string
     Results:
-      type: array
-      items:
-        $ref: '#/components/schemas/Record'
+      type: object
+      properties:
+        hits:
+          type: integer
+          description: total search results for query
+        results:
+            items:
+              type: array
+              $ref: '#/components/schemas/Record'


### PR DESCRIPTION
#### What does this PR do?

Updates openapi spec to match current implementation

#### Helpful background context

Remaining disparities between this spec and our implementation:
- thumbnail: proposed removal in DIP ticket (DIP-190)
- country needs a lookup table (DIP-186)
- array vs string: (DIP-191)
  - format in spec is a string. in code is an array.
  - imprint in spec is a string. in code is an array.
  - publication_frequency in spec is a string. in code is an array.
- need to de-dupe (DIP-192)
  - languages
  - format
- citation: remove for 1.0? it can always come back in a future spec but I don't see us solving this anytime soon. (DIP-193)
- summary holdings (DIP-194)
- realtime holdings (DIP-195)

#### How can a reviewer manually see the effects of these changes?

You can view a Swagger UI representation of the OpenAPI Spec from this branch here:
https://bl.ocks.org/JPrevost/raw/5fd35038ea2948124421b8b55a2457c1/

Or you can check out this branch and launch via a webserver such as `python -m SimpleHTTPServer 8000` and then open `/docs` you can view a Swagger UI representation of the OpenAPI Spec for this project.

Compare those expected responses and model with what is implemented in this PR build (after registering).

#### What are the relevant tickets?

- https://mitlibraries.atlassian.net/browse/DIP-173

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
