### PR TITLE
Update spec to match field mapping decisions

### DIFF
--- a/app/views/api/v1/search/_base.json.jbuilder
+++ b/app/views/api/v1/search/_base.json.jbuilder
@@ -3,11 +3,11 @@ json.source result['source']
 json.source_link result['source_link']
 json.full_record_link api_v1_record_url(result['identifier'])
 json.content_type result['content_type']
-json.format result['format']
+json.format result['format'] if result['format']
 json.realtime_holdings_link 'Not Yet Implemented'
 json.publication_date result['publication_date']
 json.title result['title']
-json.links result['links']
+json.links result['links'] if result['links']
 json.authors result['creators']
 json.subjects result['subjects']
 json.summary_holdings ['Not Yet Implemented']

--- a/openapi.yml
+++ b/openapi.yml
@@ -270,7 +270,9 @@ components:
             summary:
               type: string
             imprint:
-              type: string
+              type: array
+              items:
+                type: string
             languages:
               description: <http://id.loc.gov/ontologies/bibframe.html#c_Language>
               type: array
@@ -295,7 +297,9 @@ components:
               type: string
             publication_frequency:
               description: <http://id.loc.gov/ontologies/bibframe.html#p_frequency>
-              type: string
+              type: array
+              items:
+                type: string
     Results:
       type: object
       properties:


### PR DESCRIPTION


#### What does this PR do?
Updates the spec so imprint and publication_frequency fields match our record field types.
Also removes "null" from results for fields that are sometimes not present in record (format and links).

#### What are the relevant tickets?

- https://mitlibraries.atlassian.net/browse/DIP-191

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
