### PR TITLE
Rails changed behavior in a dot release and broke this

### DIFF
--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -7,7 +7,7 @@ Rails.application.configure do
     exceptions = %w(controller action format id)
     {
       params: event.payload[:params].except(*exceptions),
-      time: event.time.utc().iso8601(3),
+      time: Time.now.utc().iso8601(3),
     }
   end
 


### PR DESCRIPTION
#### What does this PR do?

Updates Lograge timestamp to avoid change in recent Rails dot release.

#### What are the relevant tickets?

- https://mitlibraries.atlassian.net/browse/DIP-222

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO