### PR TITLE
Redirect to preferred domain if it is set in ENV

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ end
 group :test do
   gem 'capybara', '>= 2.15'
   gem 'chromedriver-helper'
+  gem 'climate_control'
   gem 'coveralls', require: false
   gem 'selenium-webdriver'
   gem 'timecop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,7 @@ GEM
     chromedriver-helper (2.1.0)
       archive-zip (~> 0.10)
       nokogiri (~> 1.8)
+    climate_control (0.2.0)
     concurrent-ruby (1.1.3)
     coveralls (0.7.1)
       multi_json (~> 1.3)
@@ -303,6 +304,7 @@ DEPENDENCIES
   byebug
   capybara (>= 2.15)
   chromedriver-helper
+  climate_control
   coveralls
   devise
   dotenv-rails

--- a/README.md
+++ b/README.md
@@ -44,3 +44,6 @@ additional records with a standardized template.
 
 # Optional Environment Variables (all ENVs)
 - `ELASTICSEARCH_LOG` if `true`, verbosely logs ElasticSearch queries
+- `PREFERRED_DOMAIN` - set this to the domain you would like to to use. Any
+  other requests that come to the app will redirect to the root of this domain.
+  This is useful to prevent access to herokuapp.com domains.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,14 @@
 class ApplicationController < ActionController::Base
+  before_action :ensure_domain
+
+  private
+
+  # redirects herokuapp domains and old domains to preferred domains
+  def ensure_domain
+    return unless ENV['PREFERRED_DOMAIN']
+    return if request.host == ENV['PREFERRED_DOMAIN']
+
+    Rails.logger.info("Handling Domain Redirect: #{request.host}")
+    redirect_to "https://#{ENV['PREFERRED_DOMAIN']}", status: :moved_permanently
+  end
 end

--- a/test/integration/redirect_domains_test.rb
+++ b/test/integration/redirect_domains_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+
+class RedirectDomainsTest < ActionDispatch::IntegrationTest
+  test 'no PREFERRED_DOMAIN' do
+    get '/'
+    assert_response :success
+    assert_equal('/', @request.path)
+  end
+
+  test 'PREFERRED_DOMAIN domain matches request host' do
+    ClimateControl.modify(PREFERRED_DOMAIN: 'example.org') do
+      get 'http://example.org/'
+      assert_response :success
+      assert_equal('example.org', request.host)
+      assert_equal('/', @request.path)
+    end
+  end
+
+  test 'PREFERRED_DOMAIN does not match request host' do
+    ClimateControl.modify(PREFERRED_DOMAIN: 'example.com') do
+      get 'http://example.org/'
+      assert_response :redirect
+      assert_equal('example.org', request.host)
+      follow_redirect!
+      assert_equal('example.com', request.host)
+      assert_equal('/', @request.path)
+    end
+  end
+end


### PR DESCRIPTION
#### What does this PR do?

Setting `PREFERRED_DOMAIN` will redirect any requests to any other domain that hit this app to redirect to the root of the PREFERRED_DOMAIN.

#### Helpful background context

This is useful to prevent inadvertent access to herokuapp.com domains in production, as well as handling any legacy domains if they exist (which they don't in this app...at least yet).

#### How can a reviewer manually see the effects of these changes?

If you set the `PREFERRED_DOMAIN` ENV and then try to access the PR build, you'll get redirected to whatever you set... which will only be partially testing this as you won't end up on the PR build. So yeah, it mostly needs to be fully confirmed in production.

#### What are the relevant tickets?

- https://mitlibraries.atlassian.net/browse/DIP-202

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
YES
