### PR TITLE
content_format and literary_form

### DIFF
--- a/app/views/api/v1/search/_base.json.jbuilder
+++ b/app/views/api/v1/search/_base.json.jbuilder
@@ -3,7 +3,7 @@ json.source result['source']
 json.source_link result['source_link']
 json.full_record_link api_v1_record_url(result['identifier'])
 json.content_type result['content_type']
-json.format result['format'] if result['format']
+json.content_format result['format'] if result['format']
 json.realtime_holdings_link 'Not Yet Implemented'
 json.publication_date result['publication_date']
 json.title result['title']

--- a/app/views/api/v1/search/_extended.json.jbuilder
+++ b/app/views/api/v1/search/_extended.json.jbuilder
@@ -17,3 +17,4 @@ json.notes result['notes'] if result['notes']
 if result['publication_frequency']
   json.publication_frequency result['publication_frequency']
 end
+json.literary_form result['literary_form'] if result['literary_form']

--- a/openapi.yml
+++ b/openapi.yml
@@ -3,13 +3,13 @@ info:
   version: 0.0.4
   title: MIT Libraries Discovery API
 servers:
-  - url: 'https://timdex-prod.herokuapp.com/api/v1'
+  - url: 'https://timdex.mit.edu/api/v1'
 tags:
   - name: Authenticate
     description: Authenticate with username / password to retrieve JWT Token
     externalDocs:
       description: Register for an account
-      url: 'https://timdex-prod.herokuapp.com'
+      url: 'https://timdex.mit.edu'
   - name: Search
     description: Query TIMDEX to identify records of interest.
   - name: Retrieve
@@ -70,8 +70,8 @@ paths:
             type: array
             items:
               type: string
-        - name: format[]
-          description: Must use exact terminology from index, such as from a previous search result. Multiple values can be supplied like `?q=term&format[]=format1&format[]=format2`
+        - name: content_format[]
+          description: Must use exact terminology from index, such as from a previous search result. Multiple values can be supplied like `?q=term&content_format[]=format1&content_format[]=format2`
           in: query
           schema:
             type: array
@@ -214,7 +214,7 @@ components:
             High level categorization of the type of content, such as text,
             still image, audio, etc. <http://purl.org/dc/terms/type>
           type: string
-        format:
+        content_format:
           description: >-
             High level categorization of the content format, such as online
             resource, CD, book, etc. <http://purl.org/dc/elements/1.1/format>
@@ -349,7 +349,7 @@ components:
               name:
                 type: string
                 count: integer
-        format:
+        content_format:
           type: array
           items:
             type: object


### PR DESCRIPTION
#### What does this PR do?

- `format` is a reserved word for rails query strings so I changed our API to expect `content_format`
 - adds `literary_form` to record display as it was inadvertently left out previously
- updates url in spec to use our preferred domain

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
