### PR TITLE
Replace 'country_of_publication' with 'place_of_publication' in data model

### DIFF
--- a/app/views/api/v1/search/_extended.json.jbuilder
+++ b/app/views/api/v1/search/_extended.json.jbuilder
@@ -3,7 +3,7 @@ json.issns result['issns'] if result['issns']
 json.dois result['dois'] if result['dois']
 json.available 'Not Yet Implemented'
 json.alternate_titles result['alternate_titles'] if result['alternate_titles']
-json.country_of_publication result['country_of_publication']
+json.place_of_publication result['place_of_publication']
 json.languages result['languages'] if result['languages']
 json.call_numbers result['call_numbers'] if result['call_numbers']
 json.edition result['edition'] if result['edition']

--- a/openapi.yml
+++ b/openapi.yml
@@ -267,7 +267,7 @@ components:
               type: array
               items:
                 type: string
-            country_of_publication:
+            place_of_publication:
                 type: string
             summary:
               type: string

--- a/test/vcr_cassettes/record_001714562.yml
+++ b/test/vcr_cassettes/record_001714562.yml
@@ -27,7 +27,7 @@ http_interactions:
         added entry","value":["Phillips, Sean."]}],"subjects":["Zombies Comic books,
         strips, etc.","Science fiction comic books, strips, etc.","Young adult fiction,
         American."],"isbns":["0785126082 (hbk.)","9780785126089 (hbk.)","0785120149
-        (pbk.)","9780785120148 (pbk.)","078512277X (hbk.)","9780785122777 (hbk.)"],"oclcs":["(OCoLC)64961966","(OCoLC)144518185"],"country_of_publication":"nyu","languages":["English"],"publication_date":"2006","content_type":"Text","call_numbers":["PN6728.M367
+        (pbk.)","9780785120148 (pbk.)","078512277X (hbk.)","9780785122777 (hbk.)"],"oclcs":["(OCoLC)64961966","(OCoLC)144518185"],"place_of_publication":"nyu","languages":["English"],"publication_date":"2006","content_type":"Text","call_numbers":["PN6728.M367
         K57 2006","741.5973"],"imprint":["New York : Marvel ; London : Diamond [distributor],
         2006."],"physical_description":"1 v. (unpaged) : chiefly col. ill. ; 29 cm.","notes":["writer,
         Robert Kirkman ; artist, Sean Phillips."],"summary":["Torn from the pages


### PR DESCRIPTION
#### What does this PR do?

Replaces 'country_of_publication' with 'place_of_publication' in the data model, because many MARC records use state or other location types that are not countries.

#### What are the relevant tickets?

- https://mitlibraries.atlassian.net/browse/DIP-221

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
