### PR TITLE
Remove content_format field and add format to holdings fields

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -275,6 +275,9 @@
           },
           "notes": {
             "type": "string"
+          },
+          "format": {
+            "type": "string"
           }
         }
       },


### PR DESCRIPTION
#### What does this PR do?
Removes content_format field from record and instead includes format in holdings, since we often have multiple holdings of a single item in different formats (e.g., a print volume and an electronic resource). This decision was made with input from metadata folks who agreed that it makes the most sense. Note that "Internet resource" holdings do not list a format, since the location is already clearly defined as "Internet resource" and format would be identical to that.

This also removes content_format from the aggregations, since it is no longer its own field but rather a subfield of holdings.

#### What are the relevant tickets?

- https://mitlibraries.atlassian.net/browse/DIP-149

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
