### PR TITLE
Use new exact_value title matches to boost results

### DIFF
--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -51,9 +51,40 @@ module Api
       def query
         {
           bool: {
+            should: [
+              {
+                prefix: {
+                  'title.exact_value': {
+                    value: params[:q].downcase,
+                    boost: 15.0
+                  }
+                }
+              },
+              {
+                term: {
+                  title: {
+                    value: params[:q].downcase,
+                    boost: 1.0
+                  }
+                }
+              },
+              {
+                nested: {
+                  path: 'contributors',
+                  query: {
+                    term: {
+                      'contributors.value': {
+                        value: params[:q].downcase,
+                        boost: 0.1
+                      }
+                    }
+                  }
+                }
+              }
+            ],
             must: {
               multi_match: {
-                query: params[:q]
+                query: params[:q].downcase
               }
             },
             filter: filters


### PR DESCRIPTION
#### What does this PR do?

This boosts a lot on exact title matches, and a bit on any title match, and even less on contrbutor matches (non-exact).

The specific values are not well tuned yet, but are a good baseline starting point. These will likely move to configuration later, but for now we have magic numbers in code. Yay.

#### How can a reviewer manually see the effects of these changes?

The PR build will be setup to use the staging Elasticsearch service which has been populated with an unmerged set of Mario changes necessary to see these changes. If you prefer to see this locally, check out the appropriate Mario branch and index from that.

#### What are the relevant tickets?

- https://mitlibraries.atlassian.net/browse/DIP-794

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO