### PR TITLE
Update openapi to show optional security

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -40,7 +40,7 @@
     window.onload = function() {
       // Begin Swagger UI call region
       const ui = SwaggerUIBundle({
-        url: "../openapi.yml",
+        url: "../openapi.json",
         dom_id: '#swagger-ui',
         deepLinking: true,
         presets: [

--- a/docs/rapidoc.html
+++ b/docs/rapidoc.html
@@ -1,0 +1,15 @@
+<!doctype html> <!-- Important: must specify -->
+ <html>
+ <head>
+   <meta charset="utf-8"> <!-- Important: rapi-doc uses utf8 charecters -->
+   <script src="https://unpkg.com/rapidoc/dist/rapidoc-min.js"></script>
+ </head>
+ <body>
+   <rapi-doc
+     spec-url="../openapi.json"
+     allow-spec-url-load="false"
+     allow-spec-file-load="false"
+     theme="dark"
+   > </rapi-doc>
+ </body>
+ </html>

--- a/docs/redoc.html
+++ b/docs/redoc.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>ReDoc</title>
+    <!-- needed for adaptive design -->
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
+
+    <!--
+    ReDoc doesn't change outer page styles
+    -->
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+      }
+    </style>
+
+    <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
+
+
+  </head>
+  <body>
+
+    <redoc></redoc>
+
+    <script>
+      Redoc.init('../openapi.json', {
+        scrollYOffset: 50,
+        showExtensions: true
+      })
+    </script>
+  </body>
+</html>

--- a/openapi.json
+++ b/openapi.json
@@ -191,6 +191,7 @@
           }
         ],
         "security": [
+          {},
           {
             "jwtAuth": []
           }
@@ -234,6 +235,7 @@
           }
         ],
         "security": [
+          {},
           {
             "jwtAuth": []
           }


### PR DESCRIPTION
#### What does this PR do?

This updates the openapi spec to show the optional security of "none". However, most documentation generators have no idea what to do with this even if it is officially part of the spec.

#### Helpful background context

This also fixes the live swaggerui docs that load via github pages to use the json file and not fail looking for yaml we changed months ago as well as adding to additional generators so we can discuss them.

timdex.mit.edu still points to stoplight as our official documentation but as we've seen problems specifically around the authentication options we are exploring other options and moving these to our repo will allow others to see the docs live based on our current spec.

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
Not really.