### PR TITLE
Provides option to return full records for search

### DIFF
--- a/app/views/api/v1/search/search.json.jbuilder
+++ b/app/views/api/v1/search/search.json.jbuilder
@@ -7,6 +7,9 @@ else
 
   json.results @results['hits']['hits'] do |result|
     json.partial! partial: 'base', locals: { result: result['_source'] }
+    if params[:full].present? && params[:full].downcase != 'false'
+      json.partial! partial: 'extended', locals: { result: result['_source'] }
+    end
   end
 
   json.partial! partial: 'aggregations'

--- a/openapi.json
+++ b/openapi.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.2",
   "info": {
-    "version": "0.0.8",
+    "version": "0.0.9",
     "title": "MIT Libraries Discovery API",
     "description": "MIT Libraries Discovery API. Register for an optional account at [https://timdex.mit.edu](https://timdex.mit.edu)\n\nAnonymous access is rate limited. Registering and using JWT tokens removes the rate limit. If you run into issues with tokens, we're happy to help!\n",
     "contact": {
@@ -107,6 +107,15 @@
             "required": true,
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "name": "full",
+            "description": "If present and not `false`, returns full records instead of the default brief records.",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "default": "false"
             }
           },
           {


### PR DESCRIPTION
#### What does this PR do?

For users with specific needs, this could save a significant number of API requests by allowing them to signal they need the full records for all results instead of having to request record one at a time in a loop.

#### How can a reviewer manually see the effects of these changes?

Do a search.
https://timdex-stage-pr-119.herokuapp.com/api/v1/search?q=thesis%20thesis

Add `&full=true`. Note the additional fields are returned.
https://timdex-stage-pr-119.herokuapp.com/api/v1/search?q=thesis%20thesis&full=true

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
