### PR TITLE
Allow periods in id parameter to record route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       get 'auth', to: 'auth#auth'
       get 'search', to: 'search#search'
-      get 'record/:id', to: 'search#record', as: 'record'
+      get 'record/:id', to: 'search#record', as: 'record', constraints: { id: /[^\/]+/ }
       get 'ping', to: 'search#ping'
     end
   end

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -70,6 +70,17 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test 'record with a period in the id' do
+    token = JWTWrapper.encode(user_id: users(:yo).id)
+    VCR.use_cassette('record period') do
+      get '/api/v1/record/MIT:archivespace:MC.0044',
+          headers: { 'Authorization': "Bearer #{token}" }
+          assert_equal(200, response.status)
+          json = JSON.parse(response.body)
+          assert_equal('MIT:archivespace:MC.0044', json['id'])
+    end
+  end
+
   test 'pagination' do
     token = JWTWrapper.encode(user_id: users(:yo).id)
     VCR.use_cassette('pagination') do

--- a/test/vcr_cassettes/record_period.yml
+++ b/test/vcr_cassettes/record_period.yml
@@ -1,0 +1,51 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:9200/timdex-prod/_search
+    body:
+      encoding: UTF-8
+      string: '{"query":{"ids":{"values":["MIT:archivespace:MC.0044"]}}}'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '1057'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"took":13,"timed_out":false,"_shards":{"total":10,"successful":10,"skipped":0,"failed":0},"hits":{"total":1,"max_score":1.0,"hits":[{"_index":"aspace-2019-10-30t15:11:31z","_type":"Record","_id":"MIT:archivespace:MC.0044","_score":1.0,"_source":{"identifier":"MIT:archivespace:MC.0044","source":"MIT
+        ArchivesSpace","source_link":"https://archivesspace.mit.edu/repositories/2/resources/609","title":"Wigglesworth
+        family papers","contributors":[{"kind":"Family","value":"Wigglesworth"}],"subjects":["Wigglesworth","Wigglesworth,
+        George","Wigglesworth, Thomas","Norton, Charles Eliot","Pickering, Timothy"],"languages":["English"],"publication_date":"1791-1909","physical_description":"0.6
+        Cubic Feet; 2 manuscript boxes","notes":["Access note: The collection is open
+        for research.","Intellectual Property Rights: \nAccess to collections in Distinctive
+        Collections and Special Collections is not authorization to publish. Separate
+        written application for permission to publish must be made to Distinctive
+        Collections. Copyright of some items in this collection may be held by respective
+        creators, not by the donor of the collection.\n","Biographical note\n\nGeorge
+        Wigglesworth, 1853-1930, LL.B. 1878, Harvard University, was treasurer of
+        the Massachusetts Institute of Technology (MIT), 1891-1907, and a member of
+        the MIT Corporation, 1881-1930. He practiced law in Boston, and was active
+        in numerous educational and charitable institutions in Boston, among them
+        the Harvard Board of Overseers and Massachusetts General Hospital, both of
+        which he served as president.\n\n\nThomas Wigglesworth, 1814-1907, was a Boston
+        merchant involved in trade with the Far East.\n"],"holdings":[{"location":"\nMaterials
+        are stored off-site. Advance notice is required for use.\n"}],"citation":"\nWilgglesworth
+        Family Papers, MC 44, box X. Massachusetts Institute of Technology, Department
+        of Distinctive Collections, Cambridge, Massachusetts.\n"}}]}}'
+    http_version: 
+  recorded_at: Tue, 12 Nov 2019 19:35:52 GMT
+recorded_with: VCR 5.0.0


### PR DESCRIPTION
By default, Rails assumes anything after a period identifies a request
format such as html or json.
https://guides.rubyonrails.org/routing.html#specifying-constraints

However, our record IDs in aspace contain periods. This change, as
documented in the official Rails documentation, prevents the Rails
defaults from breaking our ID patterns (as sketchy as our patterns may
be).

#### What does this PR do?
A few sentences describing the overall goals of the pull request's commits.
Why are we making these changes? Is there more work to be done to fully
achieve these goals?

#### How can a reviewer manually see the effects of these changes?

On the master branch with the sample data loaded, request:

`http://localhost:5000/api/v1/record/MIT:archivespace:MC.0044`

You should get an error.

On this branch, requesting the same URL should get you the expected record.

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
