### PR TITLE
Adds Source param in GraphQL query

### DIFF
--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -25,11 +25,13 @@ module Types
                                description: 'Search for timdex records' do
       argument :searchterm, String, required: true
       argument :from, String, required: false, default_value: '0'
+      argument :source, String, required: false, default_value: 'All'
     end
 
-    def search(searchterm:, from:)
+    def search(searchterm:, from:, source:)
       query = {}
       query[:q] = searchterm
+      query[:source] = source if source != 'All'
 
       results = Search.new.search(from, query)
 


### PR DESCRIPTION
This allows the GraphQL endpoint to limit to a single source for
targeted searches.

https://mitlibraries.atlassian.net/browse/DI-812

#### How to see this in action?

All records
```
{
  search(searchterm: "wright") {
    hits
    records {
      source
      sourceLink
      title
      links {
        text
        url
      }
    }
  }
}
```

Just Aleph
```
{
  search(searchterm: "wright", source:"MIT Aleph") {
    hits
    records {
      source
      sourceLink
      title
      links {
        text
        url
      }
    }
  }
}
```

Just ASpace
```
{
  search(searchterm: "wright", source:"MIT ArchivesSpace") {
    hits
    records {
      source
      sourceLink
      title
      links {
        text
        url
      }
    }
  }
}
```

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
