### PR TITLE
Add SENTRY_DSN env var to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ additional records with a standardized template.
 - `REQUESTS_PER_PERIOD` - requests allowed before throttling. Default is 100.
 - `REQUEST_PERIOD` - number of minutes for the period in `REQUESTS_PER_PERIOD`.
   Default is 1.
+- `SENTRY_DSN`: client key for Sentry exception logging
 
 ## Docker Compose Orchestrated Local Environment
 


### PR DESCRIPTION
#### What does this PR do?
Updates README.md to include SENTRY_DSN variable (client key required to log exceptions to Sentry). Closes #237. 

#### How can a reviewer manually see the effects of these changes?

Check the diff to see the addition.

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
