### PR TITLE
Update example query

### DIFF
--- a/app/views/static/index.html.erb
+++ b/app/views/static/index.html.erb
@@ -18,7 +18,7 @@
 
 <pre>
 {
-  search(searchterm: "kerbal") {
+  search(searchterm: "spaceflight") {
     records {
       sourceLink
       title


### PR DESCRIPTION
#### What does this PR do?
Changes the example query from 'kerbal' to 'spaceflight'.

#### Helpful background context
Due to an issue with the Aleph export, 'kerbal' does not currently return results.

#### How can a reviewer manually see the effects of these changes?
In the PR build (or local dev environment), the changes should be visible in the example query:

```
{
  search(searchterm: "spaceflight") {
    records {
      sourceLink
      title
      links {
        text
        url
      }
    }
  }
}
```

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
