### PR TITLE
Defaults ElasticSearch log level to INFO

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ additional records with a standardized template.
 ## Publishing User Facing Documentation
 
 ### Automatic generation from openapi specification
+
 - Sign into stoplight.io with an account that has access to the MIT Libraries organization
 - copy the source of `openapi.json` file from this repository to the code tab in our [stoplight model](https://next.stoplight.io/mit-libraries/timdex/version%2F1.0/openapi.oas3.yml)
 - In [Stoplight's Publish](https://next.stoplight.io/mit-libraries/timdex/version%2F1.0/timdex.hub.yml?view=/&show=publish&domain=mitlibraries-timdex.docs.stoplight.io) section, Uncheck "set live" and then click "Build"
@@ -30,7 +31,7 @@ additional records with a standardized template.
 
 ## Required Environment Variables (all ENVs)
 
-- `EMAIL_FROM`:  email address to send message from, including the registration
+- `EMAIL_FROM`: email address to send message from, including the registration
   and forgot password messages.
 - `EMAIL_URL_HOST` - base url to use when sending emails that link back to the
   application. In development, often `localhost:3000`. On heroku, often
@@ -41,6 +42,7 @@ additional records with a standardized template.
 - `ELASTICSEARCH_URL`: defaults to `http://localhost:9200`
 
 ## Production required Environment Variables
+
 - `AWS_ACCESS_KEY`
 - `AWS_ELASTICSEARCH`: boolean. Set to true to enable AWSv4 Signing
 - `AWS_SECRET_ACCESS_KEY`
@@ -51,7 +53,21 @@ additional records with a standardized template.
 - `SMTP_USER`
 
 ## Optional Environment Variables (all ENVs)
-- `ELASTICSEARCH_LOG` if `true`, verbosely logs ElasticSearch queries
+
+- `ELASTICSEARCH_LOG` if `true`, verbosely logs ElasticSearch queries.
+
+  ```text
+  NOTE: do not set this ENV at all if you want ES logging fully disabled.
+  Setting it to `false` is still setting it and you will be annoyed and
+  confused.
+  ```
+
+- `ES_LOG_LEVEL` set elasticsearch transport log level. Defaults to `INFO`.
+
+```text
+NOTE: `ELASTICSEARCH_LOG` must also be set for logging to function.
+```
+
 - `PREFERRED_DOMAIN` - set this to the domain you would like to to use. Any
   other requests that come to the app will redirect to the root of this domain.
   This is useful to prevent access to herokuapp.com domains.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -52,6 +52,10 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
+  logger           = ActiveSupport::Logger.new(STDOUT)
+  logger.formatter = config.log_formatter
+  config.logger = ActiveSupport::TaggedLogging.new(logger)
+
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker

--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -9,11 +9,11 @@ def configure_elasticsearch
 end
 
 def es_client
-  Elasticsearch::Client.new log: ENV['ELASTICSEARCH_LOG']
+  Elasticsearch::Client.new log: ENV.fetch('ELASTICSEARCH_LOG', false)
 end
 
 def aws_client
-  Elasticsearch::Client.new log: ENV['ELASTICSEARCH_LOG'],
+  Elasticsearch::Client.new log: ENV.fetch('ELASTICSEARCH_LOG', false),
                             url: ENV['ELASTICSEARCH_URL'] do |config|
     config.request :aws_sigv4,
                    credentials: Aws::Credentials.new(
@@ -26,3 +26,6 @@ def aws_client
 end
 
 Timdex::EsClient = configure_elasticsearch
+
+return unless ENV.fetch('ELASTICSEARCH_LOG', false)
+Timdex::EsClient.transport.logger.level = ENV.fetch('ES_LOG_LEVEL', 'INFO')


### PR DESCRIPTION
Our logging for ES calls was way too verbose. This defaults to INFO which seems good, but leaves the ability to easily move to DEBUG if we need the verbosity.

Also clarifies how to fully disable ES logging in README.

#### How can a reviewer manually see the effects of these changes?

In the master branch, or in our central logging, take a look at ES queries and note that if `ELASTICSEARCH_LOG` is set to anything the full es response was being logged.

On this branch, set `ELASTICSEARCH_LOG` to anything and note the verbosity is now at a nice `INFO` level. You can set `ES_LOG_LEVEL` to `DEBUG` to easily return to the mess that was there before.

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
