### PR TITLE
Fixes contributor aggregation

### DIFF
--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -53,7 +53,7 @@ module Types
       query[:q] = searchterm
       query[:content_format] = facets[:format]
       query[:content_type] = facets[:content_type]
-      query[:contributors] = facets[:contributors]
+      query[:contributor] = facets[:contributors]
       query[:language] = facets[:languages]
       query[:literary_form] = facets[:literary_form]
       query[:source] = facets[:source] if facets[:source] != 'All'

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -67,8 +67,8 @@ class Search
   def filters
     f = []
     f.push filter(@params[:collection], 'collections') if @params[:collection]
-    if @params[:contributors]
-      f.push filter(@params[:contributors], 'contributors')
+    if @params[:contributor]
+      f.push filter(@params[:contributor], 'contributors')
     end
 
     if @params[:content_type]


### PR DESCRIPTION
## Why are these changes being introduced:

* our documentation didn't match the implementation
* this fixes our implementation to use the documented syntax for the
  contributor facet

## Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/DISCO-211

## How does this address that need:

* This updates timdex to expect an array of `contributor` instead of
  `contributors`

## Document any side effects to this change:

While this updates `contributor` to match our documentation as well as
matche the other array based aggregations, it's also a bit clunky to
think about the singular / plural nature of these. We may want to
consider whether a future version of the TIMDEX API would benefit from
rethinking our pattern here.

## Example

Initial search returns 143 records and aggregation shows 2 records should return for the contributor I'll link next:

[Initial search](https://timdex-pipel-disco-211--0gr8py.herokuapp.com/api/v1/search?q=popcorn)

Applied contributor shows 1 result. Yeah, we expected 2 but this is a separate issue I'll be opening to address... but the facet applies and valid results are shown even if our math is weird around how many to expect:

[Applied facet](https://timdex-pipel-disco-211--0gr8py.herokuapp.com/api/v1/search?q=popcorn&contributor[]=marvin,%20johnny,%201897-1944.)

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
