### PR TITLE
Update Mario commands in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,5 +24,5 @@ down: ## Shutdown elasticsearch and timdex containers
 
 sampledata: ## Load sample Aleph and Aspace data. Run `up` first then wait for services.
 	docker pull mitlibraries/mario:latest
-	docker run --network timdex_default --mount type=bind,src=`pwd`/sample_data,dst=/sample_data mitlibraries/mario:latest --url http://elasticsearch:9200 ingest /sample_data/mit_test_records.mrc --auto --debug
-	docker run --network timdex_default --mount type=bind,src=`pwd`/sample_data,dst=/sample_data mitlibraries/mario:latest --url http://elasticsearch:9200 ingest /sample_data/aspace_samples.xml --auto --type archives --prefix aspace --debug
+	docker run --network timdex_default --mount type=bind,src=`pwd`/sample_data,dst=/sample_data mitlibraries/mario:latest --url http://elasticsearch:9200 ingest -s aleph --new --auto /sample_data/mit_test_records.mrc
+	docker run --network timdex_default --mount type=bind,src=`pwd`/sample_data,dst=/sample_data mitlibraries/mario:latest --url http://elasticsearch:9200 ingest -s aspace --new --auto /sample_data/aspace_samples.xml

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Note: if you run this and it fails, try again in a few seconds as ES may still b
 
 You can also run arbitrary Mario commands using a syntax like this after first running `make up`.
 
-`docker run --network timdex_default mitlibraries/mario:aspace --url http://elasticsearch:9200 YOUR_MARIO_COMMAND_HERE`
+`docker run --network timdex_default mitlibraries/mario --url http://elasticsearch:9200 YOUR_MARIO_COMMAND_HERE [e.g. indexes]`
 
 Note: if you have no indexes loaded, many mario commands will fail. Try `make sampledata` or load the data you
 need before proceeding.


### PR DESCRIPTION
#### Why these changes are being introduced:
The Mario cli was recently updated. This updates the Mario commands
used in the Makefile (and noted in the Readme) to match the new cli.

#### Side effects of this change:
None

#### Relevant ticket(s):
* https://mitlibraries.atlassian.net/browse/DISCO-261

#### What does this PR do?
A few sentences describing the overall goals of the pull request's commits.
Why are we making these changes? Is there more work to be done to fully
achieve these goals?

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
