### PR TITLE
Updates CodeClimate integraiton, badge

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,4 +1,4 @@
 plugins:
   rubocop:
     enabled: true
-    channel: rubocop-0-71
+    channel: rubocop-1-23-0

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Maintainability](https://api.codeclimate.com/v1/badges/5af08033c5f1257a1fd1/maintainability)](https://codeclimate.com/github/MITLibraries/timdex/maintainability)
+
 # TIMDEX Is Making Discovery EXcellent @ MIT
 
 This application interfaces with an ElasticSearch backend and exposes a set of


### PR DESCRIPTION
#### Why are these changes being introduced:

* CodeClimate uses a very old version of Rubocop, which we need to upate
  within .codeclimate.yml but which isn't monitored for easy updates.

#### Relevant ticket(s):

* n/a

#### How does this address that need:

* Updates the channel / version of Rubocop within .codeclimate.yml

#### Document any side effects to this change:

* This also adds the maintainability badge to the readme.
* Please note - as with our other updates to this, any changes to the codebase are out of scope for this PR.

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
