### PR TITLE
Configure Opensearch model to search single fields

### DIFF
--- a/test/models/opensearch_test.rb
+++ b/test/models/opensearch_test.rb
@@ -1,0 +1,88 @@
+require 'test_helper'
+
+class OpensearchTest < ActiveSupport::TestCase
+  test 'matches citation' do
+    os = Opensearch.new
+    os.instance_variable_set(:@params, { citation: 'foo' })
+    assert os.matches.select { |m| m[:citation] == 'foo' }
+  end
+
+  test 'matches title' do
+    os = Opensearch.new
+    os.instance_variable_set(:@params, { title: 'foo' })
+    assert os.matches.select { |m| m[:title] == 'foo' }
+  end
+
+  test 'matches contributors' do
+    os = Opensearch.new
+    os.instance_variable_set(:@params, { contributors: 'foo' })
+    assert os.matches.select { |m| m['contributors.value'] == 'foo' }
+  end
+
+  test 'matches funding_information' do
+    os = Opensearch.new
+    os.instance_variable_set(:@params, { funding_information: 'foo' })
+    assert os.matches.select { |m| m['funding_information.funder_name'] == 'foo' }
+  end
+
+  test 'matches identifiers' do
+    os = Opensearch.new
+    os.instance_variable_set(:@params, { identifiers: 'foo' })
+    assert os.matches.select { |m| m['identifiers.value'] == 'foo' }
+  end
+
+  test 'matches locations' do
+    os = Opensearch.new
+    os.instance_variable_set(:@params, { locations: 'foo' })
+    assert os.matches.select { |m| m['locations.value'] == 'foo' }
+  end
+
+  test 'matches subjects' do
+    os = Opensearch.new
+    os.instance_variable_set(:@params, { subjects: 'foo' })
+    assert os.matches.select { |m| m['subjects.value'] == 'foo' }
+  end
+
+  test 'matches everything' do
+    os = Opensearch.new
+    os.instance_variable_set(:@params, { q: 'this', citation: 'here', title: 'is', contributors: 'a',
+                                         funding_information: 'real', identifiers: 'search', locations: 'rest',
+                                         subjects: 'assured,' })
+    matches = os.matches
+    assert matches.select { |m| m[:q] == 'this' }
+    assert matches.select { |m| m[:citation] == 'here' }
+    assert matches.select { |m| m[:title] == 'is' }
+    assert matches.select { |m| m['contributors.value'] == 'a' }
+    assert matches.select { |m| m['funding_information.funder_name'] == 'real' }
+    assert matches.select { |m| m['identifiers.value'] == 'search' }
+    assert matches.select { |m| m['locations.value'] == 'rest' }
+    assert matches.select { |m| m['subjects.value'] == 'assured' }
+  end
+
+  test 'searches a single field' do
+    VCR.use_cassette('opensearch single field') do
+      params = { title: 'spice' }
+      results = Opensearch.new.search(0, params, Timdex::OSClient)
+      assert_equal "Spice it up! the best of Paquito D'Rivera.",
+                   results['hits']['hits'].first['_source']['title']
+    end
+  end
+
+  test 'searches a single field with nested subfields' do
+    VCR.use_cassette('opensearch single field nested') do
+      params = { contributors: 'mcternan' }
+      results = Opensearch.new.search(0, params, Timdex::OSClient)
+      assert_equal "A common table : 80 recipes and stories from my shared cultures /",
+                   results['hits']['hits'].first['_source']['title']
+    end
+  end
+
+  test 'searches multiple fields' do
+    VCR.use_cassette('opensearch multiple fields') do
+      params = { q: 'chinese', title: 'common', contributors: 'mcternan'}
+      results = Opensearch.new.search(0, params, Timdex::OSClient)
+      assert_equal "A common table : 80 recipes and stories from my shared cultures /",
+                   results['hits']['hits'].first['_source']['title']
+    end
+  end
+end

--- a/test/vcr_cassettes/opensearch_multiple_fields.yml
+++ b/test/vcr_cassettes/opensearch_multiple_fields.yml
@@ -1,0 +1,113 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:9200/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - 'opensearch-ruby/1.0.0 (RUBY_VERSION: 2.7.5; darwin x86_64; Faraday v1.10.0)'
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '349'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "name" : "8fa7deb19b36",
+          "cluster_name" : "docker-cluster",
+          "cluster_uuid" : "HIwmyPg1T126293eDbQXLA",
+          "version" : {
+            "distribution" : "opensearch",
+            "number" : "1.2.4",
+            "build_type" : "tar",
+            "build_hash" : "e505b10357c03ae8d26d675172402f2f2144ef0f",
+            "build_date" : "2022-01-14T03:38:06.881862Z",
+            "build_snapshot" : false,
+            "lucene_version" : "8.10.1",
+            "minimum_wire_compatibility_version" : "6.8.0",
+            "minimum_index_compatibility_version" : "6.0.0-beta1"
+          },
+          "tagline" : "The OpenSearch Project: https://opensearch.org/"
+        }
+  recorded_at: Thu, 19 May 2022 21:01:08 GMT
+- request:
+    method: post
+    uri: http://localhost:9200/timdex-prod/_search
+    body:
+      encoding: UTF-8
+      string: '{"from":0,"size":20,"query":{"bool":{"should":[{"prefix":{"title.exact_value":{"value":"chinese","boost":15.0}}},{"term":{"title":{"value":"chinese","boost":1.0}}},{"nested":{"path":"contributors","query":{"term":{"contributors.value":{"value":"chinese","boost":0.1}}}}}],"must":[{"match":{"title":"common"}},{"nested":{"path":"contributors","query":{"bool":{"must":[{"match":{"contributors.value":"mcternan"}}]}}}}],"filter":[]}},"aggregations":{"collections":{"terms":{"field":"collections.keyword"}},"contributors":{"nested":{"path":"contributors"},"aggs":{"contributor_names":{"terms":{"field":"contributors.value.keyword"}}}},"content_type":{"terms":{"field":"content_type"}},"content_format":{"terms":{"field":"format"}},"languages":{"terms":{"field":"languages.keyword"}},"literary_form":{"terms":{"field":"literary_form"}},"source":{"terms":{"field":"source"}},"subjects":{"nested":{"path":"subjects"},"aggs":{"subject_names":{"terms":{"field":"subjects.value.keyword"}}}}}}'
+    headers:
+      User-Agent:
+      - 'opensearch-ruby/1.0.0 (RUBY_VERSION: 2.7.5; darwin x86_64; Faraday v1.10.0)'
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '1947'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"took":2,"timed_out":false,"_shards":{"total":1,"successful":1,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":4.276778,"hits":[{"_index":"mario-2022-05-02t19-43-00z","_type":"_doc","_id":"mit:alma:990027672770206761","_score":4.276778,"_source":{"call_numbers":["TX724.5.A1","641.595"],"content_type":["Text"],"contents":["Breakfast
+        -- Lunch \u0026 small eats -- Date night in -- Celebrations \u0026 gatherings
+        -- On the side -- Sweet -- Drinks."],"contributors":[{"kind":"author","value":"McTernan,
+        Cynthia Chen, author."}],"dates":[{"kind":"Date of publication","value":"2018"}],"edition":"First
+        edition.","format":"Print volume","holdings":[{"call_number":"TX724.5.A1 M38
+        2018","collection":"Stacks","format":"Print volume","location":"Hayden Library"}],"identifiers":[{"kind":"isbn","value":"163565002X
+        (hardback)"},{"kind":"isbn","value":"9781635650020 (hardback)"},{"kind":"oclc","value":"1019737335"},{"kind":"oclc","value":"1061147498"},{"kind":"lccn","value":"2018287279"}],"languages":["English"],"literary_form":"nonfiction","locations":[{"kind":"Place
+        of publication","value":"New York (State)"}],"notes":[{"value":["Cynthia Chen
+        McTernan.","Includes index."]}],"physical_description":"285 pages : color
+        illustrations ; 27 cm","source":"MIT Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma990027672770206761","subjects":[{"value":["Asian
+        American cooking."]}],"summary":["In A Common Table, Two Red Bowls blogger
+        Cynthia Chen McTernan shares more than 80 Asian-inspired, modern recipes that
+        marry food from her Chinese roots, Southern upbringing, and Korean mother-in-law''s
+        table. The book chronicles Cynthia''s story alongside the recipes she and
+        her family eat every day--beginning when she met her husband at law school
+        and ate out of two battered red bowls, through the first years of her legal
+        career in New York, to when she moved to Los Angeles to start a family. As
+        Cynthia''s life has changed, her cooking has become more diverse. She shares
+        recipes that celebrate both the commonalities and the diversity of cultures:
+        her mother-in-law''s spicy Korean-inspired take on Hawaiian poke, a sticky
+        sesame peanut pie that combines Chinese peanut sesame brittle with the decadence
+        of a Southern pecan pie, and a grilled cheese topped with a crisp fried egg
+        and fiery kimchi. And of course, she shares the basics: how to make soft,
+        pillowy steamed buns, savory pork dumplings, and a simple fried rice that
+        can form the base of any meal. Asian food may have a reputation for having
+        long ingredient lists and complicated instructions, but Cynthia makes it relatable,
+        avoiding hard-to-find ingredients or equipment, and breaking down how to bring
+        Asian flavors home into your own kitchen. Above all, Cynthia believes that
+        food can bring us together around the same table, no matter where we are from.
+        The message at the heart of A Common Table is that the food we make and eat
+        is rarely the product of one culture or moment, but is richly interwoven--and
+        though some dishes might seem new or different, they are often more alike
+        than they appear. -- Amazon."],"timdex_record_id":"mit:alma:990027672770206761","title":"A
+        common table : 80 recipes and stories from my shared cultures /"}}]},"aggregations":{"languages":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"english","doc_count":1}]},"content_type":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"text","doc_count":1}]},"collections":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]},"subjects":{"doc_count":1,"subject_names":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"asian
+        american cooking.","doc_count":1}]}},"content_format":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"print
+        volume","doc_count":1}]},"literary_form":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"nonfiction","doc_count":1}]},"source":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"mit
+        alma","doc_count":1}]},"contributors":{"doc_count":1,"contributor_names":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"mcternan,
+        cynthia chen, author.","doc_count":1}]}}}}'
+  recorded_at: Thu, 19 May 2022 21:01:08 GMT
+recorded_with: VCR 6.1.0

--- a/test/vcr_cassettes/opensearch_single_field.yml
+++ b/test/vcr_cassettes/opensearch_single_field.yml
@@ -1,0 +1,77 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:9200/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - 'opensearch-ruby/1.0.0 (RUBY_VERSION: 2.7.5; darwin x86_64; Faraday v1.10.0)'
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '349'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "name" : "8fa7deb19b36",
+          "cluster_name" : "docker-cluster",
+          "cluster_uuid" : "HIwmyPg1T126293eDbQXLA",
+          "version" : {
+            "distribution" : "opensearch",
+            "number" : "1.2.4",
+            "build_type" : "tar",
+            "build_hash" : "e505b10357c03ae8d26d675172402f2f2144ef0f",
+            "build_date" : "2022-01-14T03:38:06.881862Z",
+            "build_snapshot" : false,
+            "lucene_version" : "8.10.1",
+            "minimum_wire_compatibility_version" : "6.8.0",
+            "minimum_index_compatibility_version" : "6.0.0-beta1"
+          },
+          "tagline" : "The OpenSearch Project: https://opensearch.org/"
+        }
+  recorded_at: Thu, 19 May 2022 21:00:31 GMT
+- request:
+    method: post
+    uri: http://localhost:9200/timdex-prod/_search
+    body:
+      encoding: UTF-8
+      string: '{"from":0,"size":20,"query":{"bool":{"should":null,"must":[{"match":{"title":"spice"}}],"filter":[]}},"aggregations":{"collections":{"terms":{"field":"collections.keyword"}},"contributors":{"nested":{"path":"contributors"},"aggs":{"contributor_names":{"terms":{"field":"contributors.value.keyword"}}}},"content_type":{"terms":{"field":"content_type"}},"content_format":{"terms":{"field":"format"}},"languages":{"terms":{"field":"languages.keyword"}},"literary_form":{"terms":{"field":"literary_form"}},"source":{"terms":{"field":"source"}},"subjects":{"nested":{"path":"subjects"},"aggs":{"subject_names":{"terms":{"field":"subjects.value.keyword"}}}}}}'
+    headers:
+      User-Agent:
+      - 'opensearch-ruby/1.0.0 (RUBY_VERSION: 2.7.5; darwin x86_64; Faraday v1.10.0)'
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '1507'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJ0b29rIjozLCJ0aW1lZF9vdXQiOmZhbHNlLCJfc2hhcmRzIjp7InRvdGFsIjoxLCJzdWNjZXNzZnVsIjoxLCJza2lwcGVkIjowLCJmYWlsZWQiOjB9LCJoaXRzIjp7InRvdGFsIjp7InZhbHVlIjoxLCJyZWxhdGlvbiI6ImVxIn0sIm1heF9zY29yZSI6MS41MjcxNTI3LCJoaXRzIjpbeyJfaW5kZXgiOiJtYXJpby0yMDIyLTA1LTAydDE5LTQzLTAweiIsIl90eXBlIjoiX2RvYyIsIl9pZCI6Im1pdDphbG1hOjk5MDAyNjY3MTUwMDIwNjc2MSIsIl9zY29yZSI6MS41MjcxNTI3LCJfc291cmNlIjp7ImFsdGVybmF0ZV90aXRsZXMiOlt7ImtpbmQiOiJBbHRlcm5hdGUgdGl0bGUiLCJ2YWx1ZSI6IkJlc3Qgb2YgUGFxdWl0byBEJ1JpdmVyYSJ9XSwiY2FsbF9udW1iZXJzIjpbIjc4MS42NTciXSwiY2l0YXRpb24iOiJEJ1JpdmVyYSwgUGFxdWl0byBldCBhbC4gMjAwOC4gUG9ydHJhaXRzIG9mIEN1YmEiLCJjb250ZW50X3R5cGUiOlsiU291bmQgcmVjb3JkaW5nIl0sImNvbnRlbnRzIjpbIkNodWNobyAtLSBIYXZhbmEgY2FmZSAtLSBUaGUgcGVhbnV0IHZlbmRvciAtLSBBIG5pZ2h0IGluIFR1bmlzaWEgLS0gTWFtYm8gYSBsYSBLZW50b24gLS0gRWNoYWxlIHNhbHNpdGEgLS0gRHJ1bWUgbmVncml0YSAtLSBUcm9waWNhbmEgbmlnaHRzIC0tIFdobydzIHNtb2tpbmcgLS0gVGljbyB0aWNvIC0tIFBvcnRyYWl0cyBvZiBDdWJhIC0tIEV4Y2VycHQgZnJvbSBBaXJlcyB0cm9waWNhbGVzIC0tIFdoYXQgYXJlIHlvdSBkb2luZyB0b21vcnJvdyBuaWdodCAtLSBBIG1pIHF1ZS9FbCBtYW5pc2Vyby4iXSwiY29udHJpYnV0b3JzIjpbeyJraW5kIjoiYXV0aG9yIiwidmFsdWUiOiJEJ1JpdmVyYSwgUGFxdWl0bywgMTk0OC0ifSx7ImtpbmQiOiJjb250cmlidXRvciIsInZhbHVlIjoiRCdSaXZlcmEsIFBhcXVpdG8sIDE5NDgtIn0seyJraW5kIjoiY29udHJpYnV0b3IiLCJ2YWx1ZSI6IlDDqXJleiwgRGFuaWxvLiJ9LHsia2luZCI6ImNvbnRyaWJ1dG9yIiwidmFsdWUiOiJHaWxiZXJ0LCBXb2xmZS4ifSx7ImtpbmQiOiJjb250cmlidXRvciIsInZhbHVlIjoiR2lsbGVzcGllLCBEaXp6eSwgMTkxNy0xOTkzLiJ9LHsia2luZCI6ImNvbnRyaWJ1dG9yIiwidmFsdWUiOiJQw6lyZXogUHJhZG8sIDE5MTYtMTk4OS4ifSx7ImtpbmQiOiJjb250cmlidXRvciIsInZhbHVlIjoiUGnDsWVpcm8sIElnbmFjaW8sIDE4ODgtMTk2OS4ifSx7ImtpbmQiOiJjb250cmlidXRvciIsInZhbHVlIjoiR3JlbmV0LCBFcm5lc3RvIFdvb2QuIn0seyJraW5kIjoiY29udHJpYnV0b3IiLCJ2YWx1ZSI6IlJvZGl0aSwgQ2xhdWRpby4ifSx7ImtpbmQiOiJjb250cmlidXRvciIsInZhbHVlIjoiQWJyZXUsIFplcXVpbmhhIGRlLCAxODgwLTE5MzUuIn0seyJraW5kIjoiY29udHJpYnV0b3IiLCJ2YWx1ZSI6IkdvZG95LCBMdWNpby4ifSx7ImtpbmQiOiJjb250cmlidXRvciIsInZhbHVlIjoiSGVybsOhbmRleiwgUmFmYWVsLiJ9XSwiZGF0ZXMiOlt7ImtpbmQiOiJEYXRlIG9mIHB1YmxpY2F0aW9uIiwidmFsdWUiOiIyMDA4In1dLCJpZGVudGlmaWVycyI6W3sia2luZCI6Im9jbGMiLCJ2YWx1ZSI6IjgxMTU0OTU2MiJ9XSwibGFuZ3VhZ2VzIjpbIk5vIGxpbmd1aXN0aWMgY29udGVudCJdLCJsaW5rcyI6W3sia2luZCI6IkRpZ2l0YWwgb2JqZWN0IGxpbmsiLCJ0ZXh0IjoiTmF4b3MgTXVzaWMgTGlicmFyeSIsInVybCI6Imh0dHA6Ly9CTENNSVQuTmF4b3NNdXNpY0xpYnJhcnkuY29tL2NhdGFsb2d1ZS9pdGVtLmFzcD9jaWQ9SkQtMzQyIn1dLCJsb2NhdGlvbnMiOlt7ImtpbmQiOiJQbGFjZSBvZiBwdWJsaWNhdGlvbiIsInZhbHVlIjoiTmV3IFlvcmsgKFN0YXRlKSJ9XSwibm90ZXMiOlt7InZhbHVlIjpbIlBhcXVpdG8gZCcgUml2ZXJhLCBzYXhvcGhvbmUgOyBQYXF1aXRvIGQnIFJpdmVyYSwgc29wcmFubyBzYXhvcGhvbmUuIiwiRGVzY3JpcHRpb24gYmFzZWQgb24gaGFyZCBjb3B5IHZlcnNpb24gcmVjb3JkLiJdfV0sInBoeXNpY2FsX2Rlc2NyaXB0aW9uIjoiMSBvbmxpbmUgcmVzb3VyY2UgKDEgc291bmQgZmlsZSkiLCJwdWJsaWNhdGlvbl9pbmZvcm1hdGlvbiI6WyJbTmV3IFlvcmssIE4uWS5dIDogQ2hlc2t5IFJlY29yZHMsIHAyMDA4LiJdLCJzb3VyY2UiOiJNSVQgQWxtYSIsInNvdXJjZV9saW5rIjoiaHR0cHM6Ly9taXQucHJpbW8uZXhsaWJyaXNncm91cC5jb20vZGlzY292ZXJ5L2Z1bGxkaXNwbGF5P3ZpZD0wMU1JVF9JTlNUOk1JVFx1MDAyNmRvY2lkPWFsbWE5OTAwMjY2NzE1MDAyMDY3NjEiLCJzdWJqZWN0cyI6W3sidmFsdWUiOlsiSmF6ei4iLCJMYXRpbiBqYXp6LiIsIkNsYXJpbmV0IG11c2ljIChKYXp6KSIsIlNheG9waG9uZSBtdXNpYyAoSmF6eikiXX1dLCJ0aW1kZXhfcmVjb3JkX2lkIjoibWl0OmFsbWE6OTkwMDI2NjcxNTAwMjA2NzYxIiwidGl0bGUiOiJTcGljZSBpdCB1cCEgdGhlIGJlc3Qgb2YgUGFxdWl0byBEJ1JpdmVyYS4ifX1dfSwiYWdncmVnYXRpb25zIjp7Imxhbmd1YWdlcyI6eyJkb2NfY291bnRfZXJyb3JfdXBwZXJfYm91bmQiOjAsInN1bV9vdGhlcl9kb2NfY291bnQiOjAsImJ1Y2tldHMiOlt7ImtleSI6Im5vIGxpbmd1aXN0aWMgY29udGVudCIsImRvY19jb3VudCI6MX1dfSwiY29udGVudF90eXBlIjp7ImRvY19jb3VudF9lcnJvcl91cHBlcl9ib3VuZCI6MCwic3VtX290aGVyX2RvY19jb3VudCI6MCwiYnVja2V0cyI6W3sia2V5Ijoic291bmQgcmVjb3JkaW5nIiwiZG9jX2NvdW50IjoxfV19LCJjb2xsZWN0aW9ucyI6eyJkb2NfY291bnRfZXJyb3JfdXBwZXJfYm91bmQiOjAsInN1bV9vdGhlcl9kb2NfY291bnQiOjAsImJ1Y2tldHMiOltdfSwic3ViamVjdHMiOnsiZG9jX2NvdW50IjoxLCJzdWJqZWN0X25hbWVzIjp7ImRvY19jb3VudF9lcnJvcl91cHBlcl9ib3VuZCI6MCwic3VtX290aGVyX2RvY19jb3VudCI6MCwiYnVja2V0cyI6W3sia2V5IjoiY2xhcmluZXQgbXVzaWMgKGphenopIiwiZG9jX2NvdW50IjoxfSx7ImtleSI6ImphenouIiwiZG9jX2NvdW50IjoxfSx7ImtleSI6ImxhdGluIGphenouIiwiZG9jX2NvdW50IjoxfSx7ImtleSI6InNheG9waG9uZSBtdXNpYyAoamF6eikiLCJkb2NfY291bnQiOjF9XX19LCJjb250ZW50X2Zvcm1hdCI6eyJkb2NfY291bnRfZXJyb3JfdXBwZXJfYm91bmQiOjAsInN1bV9vdGhlcl9kb2NfY291bnQiOjAsImJ1Y2tldHMiOltdfSwibGl0ZXJhcnlfZm9ybSI6eyJkb2NfY291bnRfZXJyb3JfdXBwZXJfYm91bmQiOjAsInN1bV9vdGhlcl9kb2NfY291bnQiOjAsImJ1Y2tldHMiOltdfSwic291cmNlIjp7ImRvY19jb3VudF9lcnJvcl91cHBlcl9ib3VuZCI6MCwic3VtX290aGVyX2RvY19jb3VudCI6MCwiYnVja2V0cyI6W3sia2V5IjoibWl0IGFsbWEiLCJkb2NfY291bnQiOjF9XX0sImNvbnRyaWJ1dG9ycyI6eyJkb2NfY291bnQiOjEyLCJjb250cmlidXRvcl9uYW1lcyI6eyJkb2NfY291bnRfZXJyb3JfdXBwZXJfYm91bmQiOjAsInN1bV9vdGhlcl9kb2NfY291bnQiOjEsImJ1Y2tldHMiOlt7ImtleSI6ImQncml2ZXJhLCBwYXF1aXRvLCAxOTQ4LSIsImRvY19jb3VudCI6Mn0seyJrZXkiOiJhYnJldSwgemVxdWluaGEgZGUsIDE4ODAtMTkzNS4iLCJkb2NfY291bnQiOjF9LHsia2V5IjoiZ2lsYmVydCwgd29sZmUuIiwiZG9jX2NvdW50IjoxfSx7ImtleSI6ImdpbGxlc3BpZSwgZGl6enksIDE5MTctMTk5My4iLCJkb2NfY291bnQiOjF9LHsia2V5IjoiZ29kb3ksIGx1Y2lvLiIsImRvY19jb3VudCI6MX0seyJrZXkiOiJncmVuZXQsIGVybmVzdG8gd29vZC4iLCJkb2NfY291bnQiOjF9LHsia2V5IjoiaGVybsOhbmRleiwgcmFmYWVsLiIsImRvY19jb3VudCI6MX0seyJrZXkiOiJwacOxZWlybywgaWduYWNpbywgMTg4OC0xOTY5LiIsImRvY19jb3VudCI6MX0seyJrZXkiOiJww6lyZXogcHJhZG8sIDE5MTYtMTk4OS4iLCJkb2NfY291bnQiOjF9LHsia2V5IjoicMOpcmV6LCBkYW5pbG8uIiwiZG9jX2NvdW50IjoxfV19fX19
+  recorded_at: Thu, 19 May 2022 21:00:31 GMT
+recorded_with: VCR 6.1.0

--- a/test/vcr_cassettes/opensearch_single_field_nested.yml
+++ b/test/vcr_cassettes/opensearch_single_field_nested.yml
@@ -1,0 +1,113 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:9200/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - 'opensearch-ruby/1.0.0 (RUBY_VERSION: 2.7.5; darwin x86_64; Faraday v1.10.0)'
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '349'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "name" : "8fa7deb19b36",
+          "cluster_name" : "docker-cluster",
+          "cluster_uuid" : "HIwmyPg1T126293eDbQXLA",
+          "version" : {
+            "distribution" : "opensearch",
+            "number" : "1.2.4",
+            "build_type" : "tar",
+            "build_hash" : "e505b10357c03ae8d26d675172402f2f2144ef0f",
+            "build_date" : "2022-01-14T03:38:06.881862Z",
+            "build_snapshot" : false,
+            "lucene_version" : "8.10.1",
+            "minimum_wire_compatibility_version" : "6.8.0",
+            "minimum_index_compatibility_version" : "6.0.0-beta1"
+          },
+          "tagline" : "The OpenSearch Project: https://opensearch.org/"
+        }
+  recorded_at: Thu, 19 May 2022 21:00:51 GMT
+- request:
+    method: post
+    uri: http://localhost:9200/timdex-prod/_search
+    body:
+      encoding: UTF-8
+      string: '{"from":0,"size":20,"query":{"bool":{"should":null,"must":[{"nested":{"path":"contributors","query":{"bool":{"must":[{"match":{"contributors.value":"mcternan"}}]}}}}],"filter":[]}},"aggregations":{"collections":{"terms":{"field":"collections.keyword"}},"contributors":{"nested":{"path":"contributors"},"aggs":{"contributor_names":{"terms":{"field":"contributors.value.keyword"}}}},"content_type":{"terms":{"field":"content_type"}},"content_format":{"terms":{"field":"format"}},"languages":{"terms":{"field":"languages.keyword"}},"literary_form":{"terms":{"field":"literary_form"}},"source":{"terms":{"field":"source"}},"subjects":{"nested":{"path":"subjects"},"aggs":{"subject_names":{"terms":{"field":"subjects.value.keyword"}}}}}}'
+    headers:
+      User-Agent:
+      - 'opensearch-ruby/1.0.0 (RUBY_VERSION: 2.7.5; darwin x86_64; Faraday v1.10.0)'
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '1948'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"took":2,"timed_out":false,"_shards":{"total":1,"successful":1,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":2.9549356,"hits":[{"_index":"mario-2022-05-02t19-43-00z","_type":"_doc","_id":"mit:alma:990027672770206761","_score":2.9549356,"_source":{"call_numbers":["TX724.5.A1","641.595"],"content_type":["Text"],"contents":["Breakfast
+        -- Lunch \u0026 small eats -- Date night in -- Celebrations \u0026 gatherings
+        -- On the side -- Sweet -- Drinks."],"contributors":[{"kind":"author","value":"McTernan,
+        Cynthia Chen, author."}],"dates":[{"kind":"Date of publication","value":"2018"}],"edition":"First
+        edition.","format":"Print volume","holdings":[{"call_number":"TX724.5.A1 M38
+        2018","collection":"Stacks","format":"Print volume","location":"Hayden Library"}],"identifiers":[{"kind":"isbn","value":"163565002X
+        (hardback)"},{"kind":"isbn","value":"9781635650020 (hardback)"},{"kind":"oclc","value":"1019737335"},{"kind":"oclc","value":"1061147498"},{"kind":"lccn","value":"2018287279"}],"languages":["English"],"literary_form":"nonfiction","locations":[{"kind":"Place
+        of publication","value":"New York (State)"}],"notes":[{"value":["Cynthia Chen
+        McTernan.","Includes index."]}],"physical_description":"285 pages : color
+        illustrations ; 27 cm","source":"MIT Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma990027672770206761","subjects":[{"value":["Asian
+        American cooking."]}],"summary":["In A Common Table, Two Red Bowls blogger
+        Cynthia Chen McTernan shares more than 80 Asian-inspired, modern recipes that
+        marry food from her Chinese roots, Southern upbringing, and Korean mother-in-law''s
+        table. The book chronicles Cynthia''s story alongside the recipes she and
+        her family eat every day--beginning when she met her husband at law school
+        and ate out of two battered red bowls, through the first years of her legal
+        career in New York, to when she moved to Los Angeles to start a family. As
+        Cynthia''s life has changed, her cooking has become more diverse. She shares
+        recipes that celebrate both the commonalities and the diversity of cultures:
+        her mother-in-law''s spicy Korean-inspired take on Hawaiian poke, a sticky
+        sesame peanut pie that combines Chinese peanut sesame brittle with the decadence
+        of a Southern pecan pie, and a grilled cheese topped with a crisp fried egg
+        and fiery kimchi. And of course, she shares the basics: how to make soft,
+        pillowy steamed buns, savory pork dumplings, and a simple fried rice that
+        can form the base of any meal. Asian food may have a reputation for having
+        long ingredient lists and complicated instructions, but Cynthia makes it relatable,
+        avoiding hard-to-find ingredients or equipment, and breaking down how to bring
+        Asian flavors home into your own kitchen. Above all, Cynthia believes that
+        food can bring us together around the same table, no matter where we are from.
+        The message at the heart of A Common Table is that the food we make and eat
+        is rarely the product of one culture or moment, but is richly interwoven--and
+        though some dishes might seem new or different, they are often more alike
+        than they appear. -- Amazon."],"timdex_record_id":"mit:alma:990027672770206761","title":"A
+        common table : 80 recipes and stories from my shared cultures /"}}]},"aggregations":{"languages":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"english","doc_count":1}]},"content_type":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"text","doc_count":1}]},"collections":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]},"subjects":{"doc_count":1,"subject_names":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"asian
+        american cooking.","doc_count":1}]}},"content_format":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"print
+        volume","doc_count":1}]},"literary_form":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"nonfiction","doc_count":1}]},"source":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"mit
+        alma","doc_count":1}]},"contributors":{"doc_count":1,"contributor_names":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"mcternan,
+        cynthia chen, author.","doc_count":1}]}}}}'
+  recorded_at: Thu, 19 May 2022 21:00:51 GMT
+recorded_with: VCR 6.1.0


### PR DESCRIPTION
#### Why these changes are being introduced:

The search model needs to be able to target any of the fields defined
as single-field searchable in v2.0 of the data model.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/RDI-102

#### How this addresses that need:

This enables matching the following fields in the Opensearch model:

* citation
* contributors
* funding_information
* identifiers
* locations
* subjects

(Note that title was already made searchable as part of a previous
commit.)

#### Side effects of this change:

* These fields are not yet enabled in GraphQL, so you'll need to use
REST to confirm this behavior.
* While this allows us to search a single nested subfield, it does not
it does not allow for searching multiple nested subfields. For example,
searching contributors should search both 'value' and 'identifier', but
right now we can only search 'value'.

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
