### PR TITLE
Add targeted field search to GraphQL V2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@
 .env.development
 .DS_Store
 .solargraph.yml
+.vscode

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -46,6 +46,7 @@ module Types
         argument :from, String, required: false, default_value: '0'
 
         # applied facets
+        argument :collection_facet, [String], required: false, default_value: nil
         argument :content_type_facet, String, required: false, default_value: nil
         argument :contributors_facet, [String], required: false, default_value: nil
         argument :format_facet, [String], required: false, default_value: nil
@@ -118,6 +119,7 @@ module Types
         query[:location] = location
         query[:subjects] = subjects
         query[:title] = title
+        query[:collection_facet] = facets[:collection_facet]
         query[:content_format_facet] = facets[:format_facet]
         query[:content_type_facet] = facets[:content_type_facet]
         query[:contributors_facet] = facets[:contributors_facet]
@@ -137,7 +139,7 @@ module Types
         query[:language] = facets[:languages]
         query[:literary_form] = facets[:literary_form]
         query[:source] = facets[:source] if facets[:source] != 'All'
-        query[:subjects_facet] = facets[:subjects]
+        query[:subjects] = facets[:subjects]
         query
       end
     end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -36,17 +36,23 @@ module Types
       field :search, SearchType, null: false,
                                  description: 'Search for timdex records' do
         argument :searchterm, String, required: false, default_value: nil
+        argument :citation, String, required: false, default_value: nil
+        argument :contributors, String, required: false, default_value: nil
+        argument :funding_information, String, required: false, default_value: nil
+        argument :identifiers, String, required: false, default_value: nil
+        argument :locations, String, required: false, default_value: nil
+        argument :subjects, String, required: false, default_value: nil
         argument :title, String, required: false, default_value: nil
         argument :from, String, required: false, default_value: '0'
 
         # applied facets
-        argument :content_type, String, required: false, default_value: nil
-        argument :contributors, [String], required: false, default_value: nil
-        argument :format, [String], required: false, default_value: nil
-        argument :languages, [String], required: false, default_value: nil
-        argument :literary_form, String, required: false, default_value: nil
-        argument :source, String, required: false, default_value: 'All'
-        argument :subjects, [String], required: false, default_value: nil
+        argument :content_type_facet, String, required: false, default_value: nil
+        argument :contributors_facet, [String], required: false, default_value: nil
+        argument :format_facet, [String], required: false, default_value: nil
+        argument :languages_facet, [String], required: false, default_value: nil
+        argument :literary_form_facet, String, required: false, default_value: nil
+        argument :source_facet, String, required: false, default_value: 'All'
+        argument :subjects_facet, [String], required: false, default_value: nil
       end
     else
       def record_id(id:)
@@ -73,8 +79,10 @@ module Types
     end
 
     if Flipflop.v2?
-      def search(searchterm:, title:, from:, **facets)
-        query = construct_query(searchterm, title, facets)
+      def search(searchterm:, citation:, contributors:, funding_information:, identifiers:, locations:, subjects:,
+                 title:, from:, **facets)
+        query = construct_query(searchterm, citation, contributors, funding_information, identifiers, locations,
+                                subjects, title, facets)
 
         results = Opensearch.new.search(from, query, Timdex::OSClient)
 
@@ -99,17 +107,24 @@ module Types
     end
 
     if Flipflop.v2?
-      def construct_query(searchterm, title, facets)
+      def construct_query(searchterm, citation, contributors, funding_information, identifiers, location, subjects,
+                          title, facets)
         query = {}
         query[:q] = searchterm
+        query[:citation] = citation
+        query[:contributors] = contributors
+        query[:funding_information] = funding_information
+        query[:identifiers] = identifiers
+        query[:location] = location
+        query[:subjects] = subjects
         query[:title] = title
-        query[:content_format] = facets[:format]
-        query[:content_type] = facets[:content_type]
-        query[:contributor] = facets[:contributors]
-        query[:language] = facets[:languages]
-        query[:literary_form] = facets[:literary_form]
-        query[:source] = facets[:source] if facets[:source] != 'All'
-        query[:subject] = facets[:subjects]
+        query[:content_format_facet] = facets[:format_facet]
+        query[:content_type_facet] = facets[:content_type_facet]
+        query[:contributors_facet] = facets[:contributors_facet]
+        query[:languages_facet] = facets[:languages_facet]
+        query[:literary_form_facet] = facets[:literary_form_facet]
+        query[:source_facet] = facets[:source_facet] if facets[:source_facet] != 'All'
+        query[:subjects_facet] = facets[:subjects_facet]
         query
       end
     else
@@ -122,7 +137,7 @@ module Types
         query[:language] = facets[:languages]
         query[:literary_form] = facets[:literary_form]
         query[:source] = facets[:source] if facets[:source] != 'All'
-        query[:subject] = facets[:subjects]
+        query[:subjects_facet] = facets[:subjects]
         query
       end
     end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -108,7 +108,7 @@ module Types
     end
 
     if Flipflop.v2?
-      def construct_query(searchterm, citation, contributors, funding_information, identifiers, location, subjects,
+      def construct_query(searchterm, citation, contributors, funding_information, identifiers, locations, subjects,
                           title, facets)
         query = {}
         query[:q] = searchterm
@@ -116,7 +116,7 @@ module Types
         query[:contributors] = contributors
         query[:funding_information] = funding_information
         query[:identifiers] = identifiers
-        query[:location] = location
+        query[:locations] = locations
         query[:subjects] = subjects
         query[:title] = title
         query[:collection_facet] = facets[:collection_facet]
@@ -139,7 +139,7 @@ module Types
         query[:language] = facets[:languages]
         query[:literary_form] = facets[:literary_form]
         query[:source] = facets[:source] if facets[:source] != 'All'
-        query[:subjects] = facets[:subjects]
+        query[:subject] = facets[:subjects]
         query
       end
     end

--- a/app/graphql/types/record_type.rb
+++ b/app/graphql/types/record_type.rb
@@ -151,6 +151,7 @@ module Types
       field :publication_date, String, null: true, deprecation_reason: 'Use `dates`'
       field :content_type, [String], null: true
       field :call_numbers, [String], null: true
+      field :citation, String, null: true
       field :edition, String, null: true
       field :imprint, [String], null: true, deprecation_reason: 'Use `publicationInformation`'
       field :publication_information, [String]

--- a/app/models/opensearch.rb
+++ b/app/models/opensearch.rb
@@ -69,8 +69,8 @@ class Opensearch
     m = []
     if @params[:q].present?
       m << {
-      multi_match: {
-        query: @params[:q].downcase
+        multi_match: {
+          query: @params[:q].downcase
         }
       }
     end
@@ -88,19 +88,19 @@ class Opensearch
   # https://www.elastic.co/guide/en/elasticsearch/reference/current/query-filter-context.html
   def filters
     f = []
-    f.push filter(@params[:collection], 'collections') if @params[:collection]
-    f.push filter(@params[:contributor], 'contributors') if @params[:contributor]
+    f.push filter(@params[:collection_facet], 'collections') if @params[:collection_facet]
+    f.push filter(@params[:contributors_facet], 'contributors') if @params[:contributors_facet]
 
-    f.push filter_single(@params[:content_type], 'content_type') if @params[:content_type]
+    f.push filter_single(@params[:content_type_facet], 'content_type') if @params[:content_type_facet]
 
-    f.push filter(@params[:content_format], 'format') if @params[:content_format]
+    f.push filter(@params[:content_format_type], 'format') if @params[:content_format_type]
 
-    f.push filter(@params[:language], 'languages') if @params[:language]
+    f.push filter(@params[:languages_facet], 'languages') if @params[:languages_facet]
 
-    f.push filter_single(@params[:literary_form], 'literary_form') if @params[:literary_form]
+    f.push filter_single(@params[:literary_form_facet], 'literary_form') if @params[:literary_form_facet]
 
-    f.push filter_single(@params[:source], 'source') if @params[:source]
-    f.push filter(@params[:subject], 'subjects') if @params[:subject]
+    f.push filter_single(@params[:source_facet], 'source') if @params[:source_facet]
+    f.push filter(@params[:subjects_facet], 'subjects') if @params[:subjects_facet]
     f
   end
 

--- a/test/vcr_cassettes/graphql_v2_search_title.yml
+++ b/test/vcr_cassettes/graphql_v2_search_title.yml
@@ -1,0 +1,77 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:9200/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - 'opensearch-ruby/1.0.0 (RUBY_VERSION: 2.7.5; darwin x86_64; Faraday v1.10.0)'
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '349'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "name" : "8fa7deb19b36",
+          "cluster_name" : "docker-cluster",
+          "cluster_uuid" : "HIwmyPg1T126293eDbQXLA",
+          "version" : {
+            "distribution" : "opensearch",
+            "number" : "1.2.4",
+            "build_type" : "tar",
+            "build_hash" : "e505b10357c03ae8d26d675172402f2f2144ef0f",
+            "build_date" : "2022-01-14T03:38:06.881862Z",
+            "build_snapshot" : false,
+            "lucene_version" : "8.10.1",
+            "minimum_wire_compatibility_version" : "6.8.0",
+            "minimum_index_compatibility_version" : "6.0.0-beta1"
+          },
+          "tagline" : "The OpenSearch Project: https://opensearch.org/"
+        }
+  recorded_at: Tue, 24 May 2022 15:27:01 GMT
+- request:
+    method: post
+    uri: http://localhost:9200/timdex-prod/_search
+    body:
+      encoding: UTF-8
+      string: '{"from":"0","size":20,"query":{"bool":{"should":null,"must":[{"match":{"title":"spice"}}],"filter":[]}},"aggregations":{"collections":{"terms":{"field":"collections.keyword"}},"contributors":{"nested":{"path":"contributors"},"aggs":{"contributor_names":{"terms":{"field":"contributors.value.keyword"}}}},"content_type":{"terms":{"field":"content_type"}},"content_format":{"terms":{"field":"format"}},"languages":{"terms":{"field":"languages.keyword"}},"literary_form":{"terms":{"field":"literary_form"}},"source":{"terms":{"field":"source"}},"subjects":{"nested":{"path":"subjects"},"aggs":{"subject_names":{"terms":{"field":"subjects.value.keyword"}}}}}}'
+    headers:
+      User-Agent:
+      - 'opensearch-ruby/1.0.0 (RUBY_VERSION: 2.7.5; darwin x86_64; Faraday v1.10.0)'
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '1507'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJ0b29rIjo1LCJ0aW1lZF9vdXQiOmZhbHNlLCJfc2hhcmRzIjp7InRvdGFsIjoxLCJzdWNjZXNzZnVsIjoxLCJza2lwcGVkIjowLCJmYWlsZWQiOjB9LCJoaXRzIjp7InRvdGFsIjp7InZhbHVlIjoxLCJyZWxhdGlvbiI6ImVxIn0sIm1heF9zY29yZSI6MS41MjcxNTI3LCJoaXRzIjpbeyJfaW5kZXgiOiJtYXJpby0yMDIyLTA1LTAydDE5LTQzLTAweiIsIl90eXBlIjoiX2RvYyIsIl9pZCI6Im1pdDphbG1hOjk5MDAyNjY3MTUwMDIwNjc2MSIsIl9zY29yZSI6MS41MjcxNTI3LCJfc291cmNlIjp7ImFsdGVybmF0ZV90aXRsZXMiOlt7ImtpbmQiOiJBbHRlcm5hdGUgdGl0bGUiLCJ2YWx1ZSI6IkJlc3Qgb2YgUGFxdWl0byBEJ1JpdmVyYSJ9XSwiY2FsbF9udW1iZXJzIjpbIjc4MS42NTciXSwiY2l0YXRpb24iOiJEJ1JpdmVyYSwgUGFxdWl0byBldCBhbC4gMjAwOC4gUG9ydHJhaXRzIG9mIEN1YmEiLCJjb250ZW50X3R5cGUiOlsiU291bmQgcmVjb3JkaW5nIl0sImNvbnRlbnRzIjpbIkNodWNobyAtLSBIYXZhbmEgY2FmZSAtLSBUaGUgcGVhbnV0IHZlbmRvciAtLSBBIG5pZ2h0IGluIFR1bmlzaWEgLS0gTWFtYm8gYSBsYSBLZW50b24gLS0gRWNoYWxlIHNhbHNpdGEgLS0gRHJ1bWUgbmVncml0YSAtLSBUcm9waWNhbmEgbmlnaHRzIC0tIFdobydzIHNtb2tpbmcgLS0gVGljbyB0aWNvIC0tIFBvcnRyYWl0cyBvZiBDdWJhIC0tIEV4Y2VycHQgZnJvbSBBaXJlcyB0cm9waWNhbGVzIC0tIFdoYXQgYXJlIHlvdSBkb2luZyB0b21vcnJvdyBuaWdodCAtLSBBIG1pIHF1ZS9FbCBtYW5pc2Vyby4iXSwiY29udHJpYnV0b3JzIjpbeyJraW5kIjoiYXV0aG9yIiwidmFsdWUiOiJEJ1JpdmVyYSwgUGFxdWl0bywgMTk0OC0ifSx7ImtpbmQiOiJjb250cmlidXRvciIsInZhbHVlIjoiRCdSaXZlcmEsIFBhcXVpdG8sIDE5NDgtIn0seyJraW5kIjoiY29udHJpYnV0b3IiLCJ2YWx1ZSI6IlDDqXJleiwgRGFuaWxvLiJ9LHsia2luZCI6ImNvbnRyaWJ1dG9yIiwidmFsdWUiOiJHaWxiZXJ0LCBXb2xmZS4ifSx7ImtpbmQiOiJjb250cmlidXRvciIsInZhbHVlIjoiR2lsbGVzcGllLCBEaXp6eSwgMTkxNy0xOTkzLiJ9LHsia2luZCI6ImNvbnRyaWJ1dG9yIiwidmFsdWUiOiJQw6lyZXogUHJhZG8sIDE5MTYtMTk4OS4ifSx7ImtpbmQiOiJjb250cmlidXRvciIsInZhbHVlIjoiUGnDsWVpcm8sIElnbmFjaW8sIDE4ODgtMTk2OS4ifSx7ImtpbmQiOiJjb250cmlidXRvciIsInZhbHVlIjoiR3JlbmV0LCBFcm5lc3RvIFdvb2QuIn0seyJraW5kIjoiY29udHJpYnV0b3IiLCJ2YWx1ZSI6IlJvZGl0aSwgQ2xhdWRpby4ifSx7ImtpbmQiOiJjb250cmlidXRvciIsInZhbHVlIjoiQWJyZXUsIFplcXVpbmhhIGRlLCAxODgwLTE5MzUuIn0seyJraW5kIjoiY29udHJpYnV0b3IiLCJ2YWx1ZSI6IkdvZG95LCBMdWNpby4ifSx7ImtpbmQiOiJjb250cmlidXRvciIsInZhbHVlIjoiSGVybsOhbmRleiwgUmFmYWVsLiJ9XSwiZGF0ZXMiOlt7ImtpbmQiOiJEYXRlIG9mIHB1YmxpY2F0aW9uIiwidmFsdWUiOiIyMDA4In1dLCJpZGVudGlmaWVycyI6W3sia2luZCI6Im9jbGMiLCJ2YWx1ZSI6IjgxMTU0OTU2MiJ9XSwibGFuZ3VhZ2VzIjpbIk5vIGxpbmd1aXN0aWMgY29udGVudCJdLCJsaW5rcyI6W3sia2luZCI6IkRpZ2l0YWwgb2JqZWN0IGxpbmsiLCJ0ZXh0IjoiTmF4b3MgTXVzaWMgTGlicmFyeSIsInVybCI6Imh0dHA6Ly9CTENNSVQuTmF4b3NNdXNpY0xpYnJhcnkuY29tL2NhdGFsb2d1ZS9pdGVtLmFzcD9jaWQ9SkQtMzQyIn1dLCJsb2NhdGlvbnMiOlt7ImtpbmQiOiJQbGFjZSBvZiBwdWJsaWNhdGlvbiIsInZhbHVlIjoiTmV3IFlvcmsgKFN0YXRlKSJ9XSwibm90ZXMiOlt7InZhbHVlIjpbIlBhcXVpdG8gZCcgUml2ZXJhLCBzYXhvcGhvbmUgOyBQYXF1aXRvIGQnIFJpdmVyYSwgc29wcmFubyBzYXhvcGhvbmUuIiwiRGVzY3JpcHRpb24gYmFzZWQgb24gaGFyZCBjb3B5IHZlcnNpb24gcmVjb3JkLiJdfV0sInBoeXNpY2FsX2Rlc2NyaXB0aW9uIjoiMSBvbmxpbmUgcmVzb3VyY2UgKDEgc291bmQgZmlsZSkiLCJwdWJsaWNhdGlvbl9pbmZvcm1hdGlvbiI6WyJbTmV3IFlvcmssIE4uWS5dIDogQ2hlc2t5IFJlY29yZHMsIHAyMDA4LiJdLCJzb3VyY2UiOiJNSVQgQWxtYSIsInNvdXJjZV9saW5rIjoiaHR0cHM6Ly9taXQucHJpbW8uZXhsaWJyaXNncm91cC5jb20vZGlzY292ZXJ5L2Z1bGxkaXNwbGF5P3ZpZD0wMU1JVF9JTlNUOk1JVFx1MDAyNmRvY2lkPWFsbWE5OTAwMjY2NzE1MDAyMDY3NjEiLCJzdWJqZWN0cyI6W3sidmFsdWUiOlsiSmF6ei4iLCJMYXRpbiBqYXp6LiIsIkNsYXJpbmV0IG11c2ljIChKYXp6KSIsIlNheG9waG9uZSBtdXNpYyAoSmF6eikiXX1dLCJ0aW1kZXhfcmVjb3JkX2lkIjoibWl0OmFsbWE6OTkwMDI2NjcxNTAwMjA2NzYxIiwidGl0bGUiOiJTcGljZSBpdCB1cCEgdGhlIGJlc3Qgb2YgUGFxdWl0byBEJ1JpdmVyYS4ifX1dfSwiYWdncmVnYXRpb25zIjp7Imxhbmd1YWdlcyI6eyJkb2NfY291bnRfZXJyb3JfdXBwZXJfYm91bmQiOjAsInN1bV9vdGhlcl9kb2NfY291bnQiOjAsImJ1Y2tldHMiOlt7ImtleSI6Im5vIGxpbmd1aXN0aWMgY29udGVudCIsImRvY19jb3VudCI6MX1dfSwiY29udGVudF90eXBlIjp7ImRvY19jb3VudF9lcnJvcl91cHBlcl9ib3VuZCI6MCwic3VtX290aGVyX2RvY19jb3VudCI6MCwiYnVja2V0cyI6W3sia2V5Ijoic291bmQgcmVjb3JkaW5nIiwiZG9jX2NvdW50IjoxfV19LCJjb2xsZWN0aW9ucyI6eyJkb2NfY291bnRfZXJyb3JfdXBwZXJfYm91bmQiOjAsInN1bV9vdGhlcl9kb2NfY291bnQiOjAsImJ1Y2tldHMiOltdfSwic3ViamVjdHMiOnsiZG9jX2NvdW50IjoxLCJzdWJqZWN0X25hbWVzIjp7ImRvY19jb3VudF9lcnJvcl91cHBlcl9ib3VuZCI6MCwic3VtX290aGVyX2RvY19jb3VudCI6MCwiYnVja2V0cyI6W3sia2V5IjoiY2xhcmluZXQgbXVzaWMgKGphenopIiwiZG9jX2NvdW50IjoxfSx7ImtleSI6ImphenouIiwiZG9jX2NvdW50IjoxfSx7ImtleSI6ImxhdGluIGphenouIiwiZG9jX2NvdW50IjoxfSx7ImtleSI6InNheG9waG9uZSBtdXNpYyAoamF6eikiLCJkb2NfY291bnQiOjF9XX19LCJjb250ZW50X2Zvcm1hdCI6eyJkb2NfY291bnRfZXJyb3JfdXBwZXJfYm91bmQiOjAsInN1bV9vdGhlcl9kb2NfY291bnQiOjAsImJ1Y2tldHMiOltdfSwibGl0ZXJhcnlfZm9ybSI6eyJkb2NfY291bnRfZXJyb3JfdXBwZXJfYm91bmQiOjAsInN1bV9vdGhlcl9kb2NfY291bnQiOjAsImJ1Y2tldHMiOltdfSwic291cmNlIjp7ImRvY19jb3VudF9lcnJvcl91cHBlcl9ib3VuZCI6MCwic3VtX290aGVyX2RvY19jb3VudCI6MCwiYnVja2V0cyI6W3sia2V5IjoibWl0IGFsbWEiLCJkb2NfY291bnQiOjF9XX0sImNvbnRyaWJ1dG9ycyI6eyJkb2NfY291bnQiOjEyLCJjb250cmlidXRvcl9uYW1lcyI6eyJkb2NfY291bnRfZXJyb3JfdXBwZXJfYm91bmQiOjAsInN1bV9vdGhlcl9kb2NfY291bnQiOjEsImJ1Y2tldHMiOlt7ImtleSI6ImQncml2ZXJhLCBwYXF1aXRvLCAxOTQ4LSIsImRvY19jb3VudCI6Mn0seyJrZXkiOiJhYnJldSwgemVxdWluaGEgZGUsIDE4ODAtMTkzNS4iLCJkb2NfY291bnQiOjF9LHsia2V5IjoiZ2lsYmVydCwgd29sZmUuIiwiZG9jX2NvdW50IjoxfSx7ImtleSI6ImdpbGxlc3BpZSwgZGl6enksIDE5MTctMTk5My4iLCJkb2NfY291bnQiOjF9LHsia2V5IjoiZ29kb3ksIGx1Y2lvLiIsImRvY19jb3VudCI6MX0seyJrZXkiOiJncmVuZXQsIGVybmVzdG8gd29vZC4iLCJkb2NfY291bnQiOjF9LHsia2V5IjoiaGVybsOhbmRleiwgcmFmYWVsLiIsImRvY19jb3VudCI6MX0seyJrZXkiOiJwacOxZWlybywgaWduYWNpbywgMTg4OC0xOTY5LiIsImRvY19jb3VudCI6MX0seyJrZXkiOiJww6lyZXogcHJhZG8sIDE5MTYtMTk4OS4iLCJkb2NfY291bnQiOjF9LHsia2V5IjoicMOpcmV6LCBkYW5pbG8uIiwiZG9jX2NvdW50IjoxfV19fX19
+  recorded_at: Tue, 24 May 2022 15:27:01 GMT
+recorded_with: VCR 6.1.0

--- a/test/vcr_cassettes/graphqlv2_search_contributors.yml
+++ b/test/vcr_cassettes/graphqlv2_search_contributors.yml
@@ -1,0 +1,77 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:9200/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - 'opensearch-ruby/1.0.0 (RUBY_VERSION: 2.7.5; darwin x86_64; Faraday v1.10.0)'
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '349'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "name" : "8fa7deb19b36",
+          "cluster_name" : "docker-cluster",
+          "cluster_uuid" : "HIwmyPg1T126293eDbQXLA",
+          "version" : {
+            "distribution" : "opensearch",
+            "number" : "1.2.4",
+            "build_type" : "tar",
+            "build_hash" : "e505b10357c03ae8d26d675172402f2f2144ef0f",
+            "build_date" : "2022-01-14T03:38:06.881862Z",
+            "build_snapshot" : false,
+            "lucene_version" : "8.10.1",
+            "minimum_wire_compatibility_version" : "6.8.0",
+            "minimum_index_compatibility_version" : "6.0.0-beta1"
+          },
+          "tagline" : "The OpenSearch Project: https://opensearch.org/"
+        }
+  recorded_at: Tue, 24 May 2022 15:36:04 GMT
+- request:
+    method: post
+    uri: http://localhost:9200/timdex-prod/_search
+    body:
+      encoding: UTF-8
+      string: '{"from":"0","size":20,"query":{"bool":{"should":null,"must":[{"nested":{"path":"contributors","query":{"bool":{"must":[{"match":{"contributors.value":"moon"}}]}}}}],"filter":[]}},"aggregations":{"collections":{"terms":{"field":"collections.keyword"}},"contributors":{"nested":{"path":"contributors"},"aggs":{"contributor_names":{"terms":{"field":"contributors.value.keyword"}}}},"content_type":{"terms":{"field":"content_type"}},"content_format":{"terms":{"field":"format"}},"languages":{"terms":{"field":"languages.keyword"}},"literary_form":{"terms":{"field":"literary_form"}},"source":{"terms":{"field":"source"}},"subjects":{"nested":{"path":"subjects"},"aggs":{"subject_names":{"terms":{"field":"subjects.value.keyword"}}}}}}'
+    headers:
+      User-Agent:
+      - 'opensearch-ruby/1.0.0 (RUBY_VERSION: 2.7.5; darwin x86_64; Faraday v1.10.0)'
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '1894'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJ0b29rIjo1LCJ0aW1lZF9vdXQiOmZhbHNlLCJfc2hhcmRzIjp7InRvdGFsIjoxLCJzdWNjZXNzZnVsIjoxLCJza2lwcGVkIjowLCJmYWlsZWQiOjB9LCJoaXRzIjp7InRvdGFsIjp7InZhbHVlIjoxLCJyZWxhdGlvbiI6ImVxIn0sIm1heF9zY29yZSI6My40ODk2NzU4LCJoaXRzIjpbeyJfaW5kZXgiOiJtYXJpby0yMDIyLTA1LTAydDE5LTQzLTAweiIsIl90eXBlIjoiX2RvYyIsIl9pZCI6Im1pdDpkc3BhY2U6MTcyMS4xLTExMzU2NiIsIl9zY29yZSI6My40ODk2NzU4LCJfc291cmNlIjp7ImNpdGF0aW9uIjoiUmFuanJhbSwgTWlrZSBLLiwgSW50YWUgTW9vbiwgYW5kIERhdmlkIEouIFBlcnJlYXVsdC4gJ1ZhcmlhYmxlLUludmVydGVyLVJlY3RpZmllci1UcmFuc2Zvcm1lcjogQSBIeWJyaWQgRWxlY3Ryb25pYyBhbmQgTWFnbmV0aWMgU3RydWN0dXJlIEVuYWJsaW5nXHUwMDI2IzEzOyBBZGp1c3RhYmxlIEhpZ2ggU3RlcC1Eb3duIENvbnZlcnNpb24gUmF0aW9zLicgMjAxNyBJRUVFIFdvcmtzaG9wIG9uIENvbnRyb2wgYW5kIE1vZGVsaW5nIGZvciBQb3dlciBFbGVjdHJvbmljcyAoQ09NUEVMIDE3KSwgOS0xMiBKdWx5LCAyMDE3LCBTdGFuZm9yZCwgQ2FsaWZvcm5pYSwgSUVFRSwgMjAxNy4iLCJjb250ZW50X3R5cGUiOlsiQXJ0aWNsZSIsIkNvbmZlcmVuY2UgcGFwZXIiXSwiY29udHJpYnV0b3JzIjpbeyJhZmZpbGlhdGlvbiI6Ik1JVCIsImtpbmQiOiJhdXRob3IiLCJtaXRfYWZmaWxpYXRlZCI6dHJ1ZSwidmFsdWUiOiJNb29uLCBJbnRhZSJ9LHsiYWZmaWxpYXRpb24iOiJNSVQiLCJraW5kIjoiYXV0aG9yIiwibWl0X2FmZmlsaWF0ZWQiOnRydWUsInZhbHVlIjoiUmFuanJhbSwgTWlrZSBLYXZpYW4ifSx7ImFmZmlsaWF0aW9uIjoiTUlUIiwia2luZCI6ImF1dGhvciIsImlkZW50aWZpZXIiOiJodHRwczovL29yY2lkLm9yZy8wMDAwLTAwMDItMDc0Ni02MTkxIiwibWl0X2FmZmlsaWF0ZWQiOnRydWUsInZhbHVlIjoiUGVycmVhdWx0LCBEYXZpZCBKIn0seyJraW5kIjoiZGVwYXJ0bWVudCIsInZhbHVlIjoiTWFzc2FjaHVzZXR0cyBJbnN0aXR1dGUgb2YgVGVjaG5vbG9neS4gRGVwYXJ0bWVudCBvZiBFbGVjdHJpY2FsIEVuZ2luZWVyaW5nIGFuZCBDb21wdXRlciBTY2llbmNlIn0seyJraW5kIjoiYXBwcm92ZXIiLCJ2YWx1ZSI6IlBlcnJlYXVsdCwgRGF2aWQgSi4ifV0sImRhdGVzIjpbeyJraW5kIjoiRGF0ZSBhY2Nlc3Npb25lZCIsInZhbHVlIjoiMjAxOC0wMi0xMlQxNToyNDoxN1oifSx7ImtpbmQiOiJEYXRlIGF2YWlsYWJsZSIsInZhbHVlIjoiMjAxOC0wMi0xMlQxNToyNDoxN1oifSx7ImtpbmQiOiJEYXRlIG9mIHB1YmxpY2F0aW9uIiwidmFsdWUiOiIyMDE3LTA4In1dLCJmaWxlX2Zvcm1hdHMiOlsiYXBwbGljYXRpb24vcGRmIiwidGV4dC9wbGFpbiJdLCJmb3JtYXQiOiJFbGVjdHJvbmljIHJlc291cmNlIiwiZnVuZGluZ19pbmZvcm1hdGlvbiI6W3siYXdhcmRfbnVtYmVyIjoiMTYwOTI0MCIsImZ1bmRlcl9uYW1lIjoiTmF0aW9uYWwgU2NpZW5jZSBGb3VuZGF0aW9uIChVLlMuKSJ9LHsiZnVuZGVyX25hbWUiOiJUZXhhcyBJbnN0cnVtZW50cyBJbmNvcnBvcmF0ZWQifSx7ImZ1bmRlcl9uYW1lIjoiRnV0dXJld2VpIFRlY2hub2xvZ2llcywgSW5jLiJ9LHsiZnVuZGVyX25hbWUiOiJNYXNzYWNodXNldHRzIEluc3RpdHV0ZSBvZiBUZWNobm9sb2d5LiBDZW50ZXIgZm9yIEludGVncmF0ZWQgQ2lyY3VpdHMgYW5kIFN5c3RlbXMifV0sImlkZW50aWZpZXJzIjpbeyJraW5kIjoiaXNibiIsInZhbHVlIjoiOTc4MTUwOTA1MzI3OCJ9LHsia2luZCI6InVyaSIsInZhbHVlIjoiaHR0cDovL2hkbC5oYW5kbGUubmV0LzE3MjEuMS8xMTM1NjYifV0sImxhbmd1YWdlcyI6WyJFbmdsaXNoIl0sImxpbmtzIjpbeyJraW5kIjoiRGlnaXRhbCBvYmplY3QgbGluayIsInVybCI6Imh0dHA6Ly9oZGwuaGFuZGxlLm5ldC8xNzIxLjEvMTEzNTY2In1dLCJyZWxhdGVkX2l0ZW1zIjpbeyJyZWxhdGlvbnNoaXAiOiJJcyBwYXJ0IG9mIiwidXJpIjoiaHR0cHM6Ly9kc3BhY2UubWl0LmVkdS9oYW5kbGUvMTcyMS4xLzQ5NDMyIn0seyJyZWxhdGlvbnNoaXAiOiJJcyBwYXJ0IG9mIiwidXJpIjoiaHR0cHM6Ly9kc3BhY2UubWl0LmVkdS9oYW5kbGUvMTcyMS4xLzQ5NDMzIn0seyJyZWxhdGlvbnNoaXAiOiJJcyB2ZXJzaW9uIG9mIiwidXJpIjoiaHR0cDovL2R4LmRvaS5vcmcvMTAuMTEwOS9DT01QRUwuMjAxNy44MDEzMzUwIn0seyJyZWxhdGlvbnNoaXAiOiJQdWJsaXNoZWQgaW4iLCJ1cmkiOiJodHRwOi8vZHguZG9pLm9yZy8xMC4xMTA5L0NPTVBFTC4yMDE3LjgwMTMzNTAifV0sInJpZ2h0cyI6W3sia2luZCI6IlRlcm1zIG9mIHVzZSIsInVyaSI6Imh0dHBzOi8vY3JlYXRpdmVjb21tb25zLm9yZy9saWNlbnNlcy9ieS1uYy1zYS8zLjAvIn1dLCJzb3VyY2UiOiIiLCJzb3VyY2VfbGluayI6IiIsInN1bW1hcnkiOlsiVGhpcyBwYXBlciBwcm9wb3NlcyBhIGh5YnJpZCBlbGVjdHJvbmljIGFuZCBtYWduZXRpYyBzdHJ1Y3R1cmUgdGhhdCBlbmFibGVzIHRyYW5zZm9ybWVycyB3aXRoIOKAnGZyYWN0aW9uYWzigJ0gYW5kIHJlY29uZmlndXJhYmxlIHR1cm5zIHJhdGlvcyAoZS5nLiAxMjowLjUsIDEyOjEsIDEyOjIpLiBUaGlzIGZ1bmN0aW9uYWxpdHkgaXMgdmFsdWFibGUgaW4gY29udmVydGVycyB3aXRoIHdpZGUgb3BlcmF0aW5nIHZvbHRhZ2UgcmFuZ2VzIGFuZCBoaWdoIHN0ZXAtdXAvZG93biwgYXMgaXQgb2ZmZXJzIGEgbWVhbnMgdG8gcmVkdWNlIGNvcHBlciBsb3NzIHdpdGhpbiB0aGUgdHJhbnNmb3JtZXIgd2hpbGUgYWxzbyBmYWNpbGl0YXRpbmcgdm9sdGFnZSBkb3VibGluZyBhbmQgcXVhZHJ1cGxpbmcuIFdlIGludHJvZHVjZSB0aGUgcHJpbmNpcGxlIG9mIG9wZXJhdGlvbiBvZiB0aGUgc3RydWN0dXJlIGFuZCBwcmVzZW50IG1vZGVscyBmb3IgaXRzIG1hZ25ldGljIGFuZCBlbGVjdHJpY2FsIGJlaGF2aW91ci4gQW4gZXhwZXJpbWVudGFsIHByb3RvdHlwZSBjYXBhYmxlIG9mIGFjY29tbW9kYXRpbmcgYSB3aWRlbHkgdmFyeWluZyBpbnB1dCAoMTIwLTM4MFtzdWJzY3JpcHQgVmRjXSkgYW5kIG91dHB1dCAoNSwgOSwgMTJWKSB2YWxpZGF0ZXMgdGhlIG9wZXJhdGluZyBwcmluY2lwbGUgYW5kIG1vZGVsbGluZyBvZiB0aGUgcHJvcG9zZWQgc3RydWN0dXJlIGFuZCBhY2hpZXZlcyBjb252ZXJzaW9uIGVmZmljaWVuY2llcyBiZXR3ZWVuIDkzLjQlIGFuZFx1MDAyNiMxMzsgOTUuNyUgYXQgMjUtMzYgVy4iXSwidGltZGV4X3JlY29yZF9pZCI6Im1pdDpkc3BhY2U6MTcyMS4xLTExMzU2NiIsInRpdGxlIjoiVmFyaWFibGUtSW52ZXJ0ZXItUmVjdGlmaWVyLVRyYW5zZm9ybWVyOiBBIEh5YnJpZCBFbGVjdHJvbmljIGFuZCBNYWduZXRpYyBTdHJ1Y3R1cmUgRW5hYmxpbmcgQWRqdXN0YWJsZSBIaWdoIFN0ZXAtRG93biBDb252ZXJzaW9uIFJhdGlvcyJ9fV19LCJhZ2dyZWdhdGlvbnMiOnsibGFuZ3VhZ2VzIjp7ImRvY19jb3VudF9lcnJvcl91cHBlcl9ib3VuZCI6MCwic3VtX290aGVyX2RvY19jb3VudCI6MCwiYnVja2V0cyI6W3sia2V5IjoiZW5nbGlzaCIsImRvY19jb3VudCI6MX1dfSwiY29udGVudF90eXBlIjp7ImRvY19jb3VudF9lcnJvcl91cHBlcl9ib3VuZCI6MCwic3VtX290aGVyX2RvY19jb3VudCI6MCwiYnVja2V0cyI6W3sia2V5IjoiYXJ0aWNsZSIsImRvY19jb3VudCI6MX0seyJrZXkiOiJjb25mZXJlbmNlIHBhcGVyIiwiZG9jX2NvdW50IjoxfV19LCJjb2xsZWN0aW9ucyI6eyJkb2NfY291bnRfZXJyb3JfdXBwZXJfYm91bmQiOjAsInN1bV9vdGhlcl9kb2NfY291bnQiOjAsImJ1Y2tldHMiOltdfSwic3ViamVjdHMiOnsiZG9jX2NvdW50IjowLCJzdWJqZWN0X25hbWVzIjp7ImRvY19jb3VudF9lcnJvcl91cHBlcl9ib3VuZCI6MCwic3VtX290aGVyX2RvY19jb3VudCI6MCwiYnVja2V0cyI6W119fSwiY29udGVudF9mb3JtYXQiOnsiZG9jX2NvdW50X2Vycm9yX3VwcGVyX2JvdW5kIjowLCJzdW1fb3RoZXJfZG9jX2NvdW50IjowLCJidWNrZXRzIjpbeyJrZXkiOiJlbGVjdHJvbmljIHJlc291cmNlIiwiZG9jX2NvdW50IjoxfV19LCJsaXRlcmFyeV9mb3JtIjp7ImRvY19jb3VudF9lcnJvcl91cHBlcl9ib3VuZCI6MCwic3VtX290aGVyX2RvY19jb3VudCI6MCwiYnVja2V0cyI6W119LCJzb3VyY2UiOnsiZG9jX2NvdW50X2Vycm9yX3VwcGVyX2JvdW5kIjowLCJzdW1fb3RoZXJfZG9jX2NvdW50IjowLCJidWNrZXRzIjpbeyJrZXkiOiIiLCJkb2NfY291bnQiOjF9XX0sImNvbnRyaWJ1dG9ycyI6eyJkb2NfY291bnQiOjUsImNvbnRyaWJ1dG9yX25hbWVzIjp7ImRvY19jb3VudF9lcnJvcl91cHBlcl9ib3VuZCI6MCwic3VtX290aGVyX2RvY19jb3VudCI6MCwiYnVja2V0cyI6W3sia2V5IjoibWFzc2FjaHVzZXR0cyBpbnN0aXR1dGUgb2YgdGVjaG5vbG9neS4gZGVwYXJ0bWVudCBvZiBlbGVjdHJpY2FsIGVuZ2luZWVyaW5nIGFuZCBjb21wdXRlciBzY2llbmNlIiwiZG9jX2NvdW50IjoxfSx7ImtleSI6Im1vb24sIGludGFlIiwiZG9jX2NvdW50IjoxfSx7ImtleSI6InBlcnJlYXVsdCwgZGF2aWQgaiIsImRvY19jb3VudCI6MX0seyJrZXkiOiJwZXJyZWF1bHQsIGRhdmlkIGouIiwiZG9jX2NvdW50IjoxfSx7ImtleSI6InJhbmpyYW0sIG1pa2Uga2F2aWFuIiwiZG9jX2NvdW50IjoxfV19fX19
+  recorded_at: Tue, 24 May 2022 15:36:04 GMT
+recorded_with: VCR 6.1.0

--- a/test/vcr_cassettes/graphqlv2_search_multiple_fields.yml
+++ b/test/vcr_cassettes/graphqlv2_search_multiple_fields.yml
@@ -1,0 +1,113 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:9200/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - 'opensearch-ruby/1.0.0 (RUBY_VERSION: 2.7.5; darwin x86_64; Faraday v1.10.0)'
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '349'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "name" : "8fa7deb19b36",
+          "cluster_name" : "docker-cluster",
+          "cluster_uuid" : "HIwmyPg1T126293eDbQXLA",
+          "version" : {
+            "distribution" : "opensearch",
+            "number" : "1.2.4",
+            "build_type" : "tar",
+            "build_hash" : "e505b10357c03ae8d26d675172402f2f2144ef0f",
+            "build_date" : "2022-01-14T03:38:06.881862Z",
+            "build_snapshot" : false,
+            "lucene_version" : "8.10.1",
+            "minimum_wire_compatibility_version" : "6.8.0",
+            "minimum_index_compatibility_version" : "6.0.0-beta1"
+          },
+          "tagline" : "The OpenSearch Project: https://opensearch.org/"
+        }
+  recorded_at: Tue, 24 May 2022 15:36:33 GMT
+- request:
+    method: post
+    uri: http://localhost:9200/timdex-prod/_search
+    body:
+      encoding: UTF-8
+      string: '{"from":"0","size":20,"query":{"bool":{"should":null,"must":[{"match":{"title":"common"}},{"nested":{"path":"contributors","query":{"bool":{"must":[{"match":{"contributors.value":"mcternan"}}]}}}},{"nested":{"path":"identifiers","query":{"bool":{"must":[{"match":{"identifiers.value":"163565002x"}}]}}}}],"filter":[]}},"aggregations":{"collections":{"terms":{"field":"collections.keyword"}},"contributors":{"nested":{"path":"contributors"},"aggs":{"contributor_names":{"terms":{"field":"contributors.value.keyword"}}}},"content_type":{"terms":{"field":"content_type"}},"content_format":{"terms":{"field":"format"}},"languages":{"terms":{"field":"languages.keyword"}},"literary_form":{"terms":{"field":"literary_form"}},"source":{"terms":{"field":"source"}},"subjects":{"nested":{"path":"subjects"},"aggs":{"subject_names":{"terms":{"field":"subjects.value.keyword"}}}}}}'
+    headers:
+      User-Agent:
+      - 'opensearch-ruby/1.0.0 (RUBY_VERSION: 2.7.5; darwin x86_64; Faraday v1.10.0)'
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '1949'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"took":5,"timed_out":false,"_shards":{"total":1,"successful":1,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":6.568732,"hits":[{"_index":"mario-2022-05-02t19-43-00z","_type":"_doc","_id":"mit:alma:990027672770206761","_score":6.568732,"_source":{"call_numbers":["TX724.5.A1","641.595"],"content_type":["Text"],"contents":["Breakfast
+        -- Lunch \u0026 small eats -- Date night in -- Celebrations \u0026 gatherings
+        -- On the side -- Sweet -- Drinks."],"contributors":[{"kind":"author","value":"McTernan,
+        Cynthia Chen, author."}],"dates":[{"kind":"Date of publication","value":"2018"}],"edition":"First
+        edition.","format":"Print volume","holdings":[{"call_number":"TX724.5.A1 M38
+        2018","collection":"Stacks","format":"Print volume","location":"Hayden Library"}],"identifiers":[{"kind":"isbn","value":"163565002X
+        (hardback)"},{"kind":"isbn","value":"9781635650020 (hardback)"},{"kind":"oclc","value":"1019737335"},{"kind":"oclc","value":"1061147498"},{"kind":"lccn","value":"2018287279"}],"languages":["English"],"literary_form":"nonfiction","locations":[{"kind":"Place
+        of publication","value":"New York (State)"}],"notes":[{"value":["Cynthia Chen
+        McTernan.","Includes index."]}],"physical_description":"285 pages : color
+        illustrations ; 27 cm","source":"MIT Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma990027672770206761","subjects":[{"value":["Asian
+        American cooking."]}],"summary":["In A Common Table, Two Red Bowls blogger
+        Cynthia Chen McTernan shares more than 80 Asian-inspired, modern recipes that
+        marry food from her Chinese roots, Southern upbringing, and Korean mother-in-law''s
+        table. The book chronicles Cynthia''s story alongside the recipes she and
+        her family eat every day--beginning when she met her husband at law school
+        and ate out of two battered red bowls, through the first years of her legal
+        career in New York, to when she moved to Los Angeles to start a family. As
+        Cynthia''s life has changed, her cooking has become more diverse. She shares
+        recipes that celebrate both the commonalities and the diversity of cultures:
+        her mother-in-law''s spicy Korean-inspired take on Hawaiian poke, a sticky
+        sesame peanut pie that combines Chinese peanut sesame brittle with the decadence
+        of a Southern pecan pie, and a grilled cheese topped with a crisp fried egg
+        and fiery kimchi. And of course, she shares the basics: how to make soft,
+        pillowy steamed buns, savory pork dumplings, and a simple fried rice that
+        can form the base of any meal. Asian food may have a reputation for having
+        long ingredient lists and complicated instructions, but Cynthia makes it relatable,
+        avoiding hard-to-find ingredients or equipment, and breaking down how to bring
+        Asian flavors home into your own kitchen. Above all, Cynthia believes that
+        food can bring us together around the same table, no matter where we are from.
+        The message at the heart of A Common Table is that the food we make and eat
+        is rarely the product of one culture or moment, but is richly interwoven--and
+        though some dishes might seem new or different, they are often more alike
+        than they appear. -- Amazon."],"timdex_record_id":"mit:alma:990027672770206761","title":"A
+        common table : 80 recipes and stories from my shared cultures /"}}]},"aggregations":{"languages":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"english","doc_count":1}]},"content_type":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"text","doc_count":1}]},"collections":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]},"subjects":{"doc_count":1,"subject_names":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"asian
+        american cooking.","doc_count":1}]}},"content_format":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"print
+        volume","doc_count":1}]},"literary_form":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"nonfiction","doc_count":1}]},"source":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"mit
+        alma","doc_count":1}]},"contributors":{"doc_count":1,"contributor_names":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"mcternan,
+        cynthia chen, author.","doc_count":1}]}}}}'
+  recorded_at: Tue, 24 May 2022 15:36:33 GMT
+recorded_with: VCR 6.1.0


### PR DESCRIPTION
#### Why these changes are being introduced:

The data model specifies that certain fields must be
single-field searchable.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/RDI-103

#### How this addresses that need:

This makes the following fields searchable in GraphQL:

* citation
* contributors
* funding_information
* identifiers
* location
* subjects
* title

This also renames the facet fields to avoid conflicts (see
side effects for more information on this).

#### Side effects of this change:

_This introduces a breaking change_. There is some overlap
between the fields above and facets. In order to accommodate both
searching and faceting, '_facet' has been added to all of the
facets in the QueryType class, and the corresponding change has
been made in the Opensearch model.

This means that anyone using the previous syntax for facets will
see their queries fail. We will want to do more analysis of how
the API is used before deploying this to prod. If we see usage
of faceting in prod, we might consider renaming the search fields
instead of the facets.

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
