### PR TITLE
Migrate from sentry-raven to sentry-ruby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,8 @@ gem 'rack-cors'
 gem 'rails', '~> 6.1.0'
 gem 'redis'
 gem 'sass-rails'
-gem 'sentry-raven'
+gem 'sentry-rails'
+gem 'sentry-ruby'
 gem 'uglifier'
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -306,8 +306,11 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
-    sentry-raven (3.1.2)
-      faraday (>= 1.0)
+    sentry-rails (5.4.1)
+      railties (>= 5.0)
+      sentry-ruby (~> 5.4.1)
+    sentry-ruby (5.4.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
     simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -391,7 +394,8 @@ DEPENDENCIES
   rubocop-rails
   sass-rails
   selenium-webdriver
-  sentry-raven
+  sentry-rails
+  sentry-ruby
   simplecov
   simplecov-lcov
   sqlite3

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,5 @@
+Sentry.init do |config|
+  return unless ENV.has_key?('SENTRY_DSN')
+  config.dsn = ENV.fetch('SENTRY_DSN')
+  config.breadcrumbs_logger = [:active_support_logger, :http_logger]
+end


### PR DESCRIPTION
#### Why these changes are being introduced:

Sentry now prefers the sentry-ruby/sentry-rails gems and has
deprecated sentry-raven.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/ENGX-88

#### How this addresses that need:

This removes sentry-raven and adds sentry-ruby and sentry-rails,
including the required initializer.

#### Side effects of this change:

None.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

YES
