### PR TITLE
Update Heroku stack and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,26 +1,23 @@
 name: CI
 on:
   push:
-    branches: [main]
+    branches: [ main ]
   pull_request:
-    branches: [main]
+    branches: [ main ]
+
 jobs:
   test:
     name: Run Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
-      - name: Setup System
-        run: |
-          sudo apt update
-          sudo apt-get install libsqlite3-dev
       - uses: ruby/setup-ruby@v1
       - uses: actions/cache@v1
         with:
           path: vendor/bundle
-          key: bundle-use-ruby-ubuntu-latest-${{ hashFiles('.ruby-version') }}-${{ hashFiles('**/Gemfile.lock') }}
+          key: bundle-use-ruby-ubuntu-22.04-${{ hashFiles('.ruby-version') }}-${{ hashFiles('**/Gemfile.lock') }}
           restore-keys: |
-            bundle-use-ruby-ubuntu-latest-${{ hashFiles('.ruby-version') }}-
+            bundle-use-ruby-ubuntu-22.04-${{ hashFiles('.ruby-version') }}-
       - name: bundle install
         run: |
           bundle config path vendor/bundle

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -346,7 +346,7 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webmock (3.16.0)
+    webmock (3.17.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)

--- a/app.json
+++ b/app.json
@@ -1,5 +1,6 @@
 {
   "name": "timdex",
+  "stack": "heroku-22",
   "scripts": {},
   "env": {
     "AWS_ACCESS_KEY": {


### PR DESCRIPTION
#### Why these changes are being introduced:

We want to update our applications to use the Heroku 22
stack, which also requires us to use Ubuntu 22.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/ENGX-180
https://mitlibraries.atlassian.net/browse/ENGX-182

#### How this addresses that need:

This updates the CI config to point to the shared workflow
and adds the Heroku stack version to app.json.

#### Side effects of this change:

To accommodate the shared CI workflow, the SimpleCov output
filename is now specified.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
