### PR TITLE
Add deprecation notice and fix doc loading

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,21 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content="MIT Libraries TIMDEX API Documentation" />
     <title>MIT Libraries TIMDEX API Documentation</title>
-    <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@4.5.2/swagger-ui.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@4.5.2/swagger-ui.css" />
   </head>
   <body>
+    <div id="deprecation" style="border: red solid; padding: 1em">
+      <h1>This REST API will be removed in early 2023.</h1>
+
+      <h2>
+        We recommend using our <a href="https://timdex.mit.edu/playground">GraphQL endpoint</a> which will remain and
+        will be soon gaining additional features including the ability to search additional sources.
+      </h2>
+
+      <p>Updated documentation coming soon. Please contact timdex@mit.edu with any questions.</p>
+    </div>
     <div id="swagger-ui"></div>
-    <script src="https://unpkg.com/swagger-ui-dist@4.5.2/swagger-ui-bundle.js" crossorigin></script>
+    <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@4.5.2/swagger-ui-bundle.js" crossorigin></script>
     <script>
       window.onload = () => {
         window.ui = SwaggerUIBundle({


### PR DESCRIPTION
Why are these changes being introduced:

* The CDN we use to pull in the swagger library no longer works for this
* We are planning to remove this API soon so adding an initial deprecation notice suggesting the GraphQL endpoint that is remaining will hopefully point potential users in a less frustrating direction if they are starting new work

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/TIMX-162

How does this address that need:

* Switches to jsdeliver to load the swagger libraries. If we were keeping these docs longterm I'd suggest we use our own CDN or embed the libraries we need in this repo to avoid this type of problem in the future
* Adds deprecation notice

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

YES (sort of. Legacy docs are now pulling from a different CDN)