### PR TITLE
Log graphql field usage

### DIFF
--- a/app/graphql/timdex_field_usage_analyzer.rb
+++ b/app/graphql/timdex_field_usage_analyzer.rb
@@ -1,0 +1,8 @@
+class TimdexFieldUsageAnalyzer < GraphQL::Analysis::AST::FieldUsage
+  # Overriding the inherited FieldUsage result to log data in a format we can work with
+  def result
+    Rails.logger.info("GraphQL used fields: #{@used_fields.to_a}")
+    Rails.logger.info("GraphQL used deprecated fields: #{@used_deprecated_fields.to_a}")
+    Rails.logger.info("GraphQL used deprecated arguments: #{@used_deprecated_arguments.to_a}")
+  end
+end

--- a/app/graphql/timdex_schema.rb
+++ b/app/graphql/timdex_schema.rb
@@ -1,4 +1,5 @@
 class TimdexSchema < GraphQL::Schema
-  # mutation(Types::MutationType)
+  query_analyzer TimdexFieldUsageAnalyzer
+
   query(Types::QueryType)
 end


### PR DESCRIPTION
Why are these changes being introduced:

* understanding which fields, including deprecated fields and arguments, are being used will help us better understand if changes we are proposing will affect actual users

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/TIMX-172

How does this address that need:

* Uses Ahead-of-Time AST Analysis features of graphql-ruby and their provided FieldUsage to log useful information via Rails.logger
* https://graphql-ruby.org/queries/ast_analysis.html
* https://graphql-ruby.org/api-doc/2.0.16/GraphQL/Analysis/AST/FieldUsage.html

Document any side effects to this change:

* Not a side effect, but we may need to adjust how/where we log to make this date more usable. Getting this into our standard logging pipeline seemed like a good place to start though and it will be easy to change the behavior of the `result` method to do something different once we decide what we need.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
