### PR TITLE
Conditional highlight requests

### DIFF
--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -8,6 +8,7 @@ class GraphqlController < ApplicationController
     context = {
       # Query context goes here, for example:
       # current_user: current_user,
+      tracers: [request_tracer]
     }
     result = TimdexSchema.execute(query, variables: variables,
                                          context: context,
@@ -45,5 +46,9 @@ class GraphqlController < ApplicationController
 
     render json: { error: { message: err.message, backtrace: err.backtrace },
                    data: {} }, status: :internal_server_error
+  end
+
+  def request_tracer
+    @request_tracer ||= TimdexRequestTracer.new
   end
 end

--- a/app/graphql/timdex_field_usage_analyzer.rb
+++ b/app/graphql/timdex_field_usage_analyzer.rb
@@ -1,8 +1,17 @@
+# TimdexFieldUsageAnalyzer largely overrides some methods from the inherited FieldUsage
+# We to log data in a format we can work with and return it to be used along with Tracers
+# to determine which fields are being requested so we can modify our OpenSearch query.
+# https://graphql-ruby.org/queries/ast_analysis.html
 class TimdexFieldUsageAnalyzer < GraphQL::Analysis::AST::FieldUsage
-  # Overriding the inherited FieldUsage result to log data in a format we can work with
+  # This overrides a GraphQL::Analysis::AST::FieldUsage method
   def result
     Rails.logger.info("GraphQL used fields: #{@used_fields.to_a}")
     Rails.logger.info("GraphQL used deprecated fields: #{@used_deprecated_fields.to_a}")
     Rails.logger.info("GraphQL used deprecated arguments: #{@used_deprecated_arguments.to_a}")
+    {
+      used_fields: @used_fields.to_a,
+      used_deprecated_fields: @used_deprecated_fields.to_a,
+      used_deprecated_arguments: @used_deprecated_arguments.to_a
+    }
   end
 end

--- a/app/graphql/timdex_request_tracer.rb
+++ b/app/graphql/timdex_request_tracer.rb
@@ -1,0 +1,15 @@
+# TimdexRequestTracer will populate the context of a query with data from our analyzers so we
+# can use the data to modify how we contstruct queries
+# It is called from the graphql_controller as part of the request context.
+# https://graphql-ruby.org/queries/executing_queries.html#context
+# https://graphql-ruby.org/queries/tracing.html
+# https://medium.com/omada-health-tech/graphql-tips-the-backend-553375e1b669
+class TimdexRequestTracer
+  attr_accessor :log_data
+
+  def trace(key, _data)
+    result = yield
+    self.log_data = result.first if key == 'analyze_query'
+    result
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -108,13 +108,17 @@ module Types
         query = construct_query(searchterm, citation, contributors, funding_information, identifiers, locations,
                                 subjects, title, source, facets)
 
-        results = Opensearch.new.search(from, query, Timdex::OSClient, index)
+        results = Opensearch.new.search(from, query, Timdex::OSClient, highlight_requested?, index)
 
         response = {}
         response[:hits] = results['hits']['total']['value']
         response[:records] = inject_hits_fields_into_source(results['hits']['hits'])
         response[:aggregations] = collapse_buckets(results['aggregations'])
         response
+      end
+
+      def highlight_requested?
+        context[:tracers].first.log_data[:used_fields].include?('Record.highlight')
       end
 
       # Long-term, we will probably want to define these fields discretely in RecordType. However, this might end up

--- a/app/models/opensearch.rb
+++ b/app/models/opensearch.rb
@@ -2,8 +2,9 @@ class Opensearch
   SIZE = 20
   MAX_PAGE = 200
 
-  def search(from, params, client, index = nil)
+  def search(from, params, client, highlight = false, index = nil)
     @params = params
+    @highlight = highlight
     index = default_index unless index.present?
     client.search(index: index,
                   body: build_query(from))
@@ -15,13 +16,16 @@ class Opensearch
 
   # Construct the json query to send to elasticsearch
   def build_query(from)
-    {
+    query_hash = {
       from: from,
       size: SIZE,
       query: query,
-      highlight: highlight,
       aggregations: aggregations
-    }.to_json
+    }
+
+    query_hash[:highlight] = highlight if @highlight
+
+    query_hash.to_json
   end
 
   # Build the query portion of the elasticsearch json

--- a/test/models/opensearch_test.rb
+++ b/test/models/opensearch_test.rb
@@ -63,7 +63,7 @@ class OpensearchTest < ActiveSupport::TestCase
     # fragile test: assumes opensearch instance with at least one index prefixed with `rdi`
     VCR.use_cassette('opensearch non-default index') do
       params = { title: 'data' }
-      results = Opensearch.new.search(0, params, Timdex::OSClient, 'rdi*')
+      results = Opensearch.new.search(0, params, Timdex::OSClient, false, 'rdi*')
       assert results['hits']['hits'].map { |hit| hit['_index'] }.uniq.map { |index| index.start_with?('rdi') }.any?
     end
   end
@@ -250,5 +250,20 @@ class OpensearchTest < ActiveSupport::TestCase
     params = { subjects_facet: ['cheese', 'ice cream'] }
 
     assert_equal(expected_filters, Opensearch.new.filters(params))
+  end
+
+  test 'highlights included if requested' do
+    os = Opensearch.new
+    os.instance_variable_set(:@params, { q: 'this' })
+    os.instance_variable_set(:@highlight, true)
+
+    assert(os.build_query(0).include?('highlight'))
+  end
+
+  test 'highlights not included by default' do
+    os = Opensearch.new
+    os.instance_variable_set(:@params, { q: 'this' })
+
+    refute(os.build_query(0).include?('highlight'))
   end
 end


### PR DESCRIPTION
Why are these changes being introduced:

* Highlights seem to introduce additional time to some opensearch queries so only requesting them when we want them makes sense

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/TIMX-173

How does this address that need:

* adds a GraphQL Tracer to expose our Analyzer data to be available before we make the opensearch call
* Updates our analyzer to return data instead of just logging (it still logs as well)
* provides a new boolean arugment to OpenSearch.new.search to indicate if `highlights` are needed
* Updates OpenSearch build_query to only include highlights if requested

Document any side effects to this change:

* We should confirm timdex-search-ui continues to work without changes
   - [x] Confirmed timdex-ui continues to work with this change with no changes (aka highlights always return)
* We should add a UI element to timdex-search-ui to only return highlights if selected
  - [x] [Jira ticket for this work](https://mitlibraries.atlassian.net/browse/TIMX-182)

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
