### PR TITLE
Dep updates including theme source change

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'graphql'
 gem 'jbuilder'
 gem 'jwt'
 gem 'lograge'
-gem 'mitlibraries-theme'
+gem 'mitlibraries-theme', git: 'https://github.com/mitlibraries/mitlibraries-theme', tag: 'v1.0.0'
 gem 'net-imap', require: false
 gem 'net-pop', require: false
 gem 'net-smtp', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,12 @@
+GIT
+  remote: https://github.com/mitlibraries/mitlibraries-theme
+  revision: f53eb6ec1f4e6c43fe39c86544e48c355e04c992
+  tag: v1.0.0
+  specs:
+    mitlibraries-theme (1.0.0)
+      rails (>= 6, < 8)
+      sassc-rails (~> 2)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -86,7 +95,7 @@ GEM
       aws-eventstream (~> 1, >= 1.0.2)
     bcrypt (3.1.18)
     bindex (0.8.1)
-    bootsnap (1.15.0)
+    bootsnap (1.16.0)
       msgpack (~> 1.2)
     builder (3.2.4)
     byebug (11.1.3)
@@ -146,7 +155,7 @@ GEM
     forwardable-extended (2.6.0)
     globalid (1.1.0)
       activesupport (>= 5.0)
-    google-protobuf (3.21.12)
+    google-protobuf (3.22.0)
     graphiql-rails (1.8.0)
       railties
       sprockets-rails
@@ -158,7 +167,7 @@ GEM
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
-    jekyll (4.3.1)
+    jekyll (4.3.2)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
@@ -193,7 +202,7 @@ GEM
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     liquid (4.0.4)
-    listen (3.7.1)
+    listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     lograge (0.12.0)
@@ -216,9 +225,6 @@ GEM
     mini_mime (1.1.2)
     mini_portile2 (2.8.1)
     minitest (5.17.0)
-    mitlibraries-theme (0.8.0)
-      rails (>= 5, < 8)
-      sassc (~> 2)
     msgpack (1.6.0)
     multi_json (1.15.0)
     net-imap (0.3.4)
@@ -249,7 +255,7 @@ GEM
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     pg (1.4.5)
-    public_suffix (5.0.0)
+    public_suffix (5.0.1)
     puma (6.1.0)
       nio4r (~> 2.0)
     racc (1.6.2)
@@ -302,20 +308,20 @@ GEM
       actionpack (>= 5.0)
       railties (>= 5.0)
     rexml (3.2.5)
-    rouge (4.0.1)
-    rubocop (1.45.1)
+    rouge (4.1.0)
+    rubocop (1.46.0)
       json (~> 2.3)
       parallel (~> 1.10)
       parser (>= 3.2.0.0)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.24.1, < 2.0)
+      rubocop-ast (>= 1.26.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
     rubocop-ast (1.26.0)
       parser (>= 3.2.1.0)
-    rubocop-rails (2.17.3)
+    rubocop-rails (2.17.4)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 1.33.0, < 2.0)
@@ -323,7 +329,7 @@ GEM
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     safe_yaml (1.0.5)
-    sass-embedded (1.57.1)
+    sass-embedded (1.58.3)
       google-protobuf (~> 3.21)
       rake (>= 10.0.0)
     sass-rails (6.0.0)
@@ -359,7 +365,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.5.4)
+    sqlite3 (1.6.1)
       mini_portile2 (~> 2.8.0)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
@@ -384,7 +390,7 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
+    webrick (1.8.1)
     websocket (1.2.9)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
@@ -417,7 +423,7 @@ DEPENDENCIES
   jwt
   listen
   lograge
-  mitlibraries-theme
+  mitlibraries-theme!
   net-imap
   net-pop
   net-smtp

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,8 @@
 class ApplicationController < ActionController::Base
   before_action :ensure_domain
 
+  helper Mitlibraries::Theme::Engine.helpers
+
   private
 
   # redirects herokuapp domains and old domains to preferred domains


### PR DESCRIPTION
- changes our theme gem to pull from our tagged releases on github rather than us releasing a version to rubygems

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

YES