### PR TITLE
Fix default index for V2 retrieve queries

### DIFF
--- a/app/models/retrieve.rb
+++ b/app/models/retrieve.rb
@@ -16,7 +16,7 @@ class Retrieve
   end
 
   def default_index
-    ENV.fetch('ELASTICSEARCH_INDEX', nil)
+    Flipflop.v2? ? ENV.fetch('OPENSEARCH_INDEX', nil) : ENV.fetch('ELASTICSEARCH_INDEX', nil)
   end
 
   def to_filter(id)

--- a/test/models/retrieve_test.rb
+++ b/test/models/retrieve_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+class RetrieveTest < ActiveSupport::TestCase
+  def setup
+    @test_strategy = Flipflop::FeatureSet.current.test!
+  end
+
+  test 'graphlv1 uses correct index for retrieve queries' do
+    @test_strategy.switch!(:v2, false)
+    assert_equal ENV.fetch('ELASTICSEARCH_INDEX'), Retrieve.new.default_index
+  end
+
+  test 'graphqlv2 uses correct index for retrieve queries' do
+    @test_strategy.switch!(:v2, true)
+    assert_equal ENV.fetch('OPENSEARCH_INDEX'), Retrieve.new.default_index
+  end
+end


### PR DESCRIPTION
Why these changes are being introduced:

The Retrieve model uses the default elasticsearch index name for V1 and V2 queries, which means that V2 retrieve queries use the wrong index name.

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/TIMX-185

How this addresses that need:

This updates Retrieve#default_index to use the default opensearch index name for V2 queries.

Side effects of this change:

The regression tests for this pass, but somewhat disingenously as we currently use the same index names in .env.test for elasticsearch and opensearch. We should probably regenerate cassettes with the latest prod data and start using the `all-current` index for V2 queries.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
