### PR TITLE
Add initial how-to guides

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -12,7 +12,7 @@ exclude:
   - architecture-decisions
 
 nav_external_links:
-  - title: Reference Docs
+  - title: Reference
     url: ./reference
     hide_icon: false # set to true to hide the external link icon - defaults to false
 

--- a/docs/guides/highlighting_search_terms.md
+++ b/docs/guides/highlighting_search_terms.md
@@ -1,0 +1,60 @@
+---
+layout: home
+title: Highlighting search terms
+parent: How-to guides
+nav_order: 7
+---
+
+## Highlighting search terms in results
+
+TIMDEX can return a list of search term matches in the results. The field that returns these matches is called
+'highlight':
+
+```graphql
+{
+  search(searchterm: "data") {
+    records {
+      highlight {
+        matchedField
+        matchedPhrases
+      }
+    }
+  }
+}
+```
+
+In the query above will return a list of matches for the search term 'data'. The 'highlight' field is nested; subfield
+'matchedField' will show the field that matched your search term, and subfield 'matchedPhrases' will show where in the
+field the search term was matched.
+
+Here's an example of a result:
+
+```json
+{
+  "highlight": [
+    {
+      "matchedField": "citation",
+      "matchedPhrases": [
+        "<span class=\"highlight\">Data</span> security and <span class=\"highlight\">data</span> processing. 1975."
+      ]
+    },
+    {
+      "matchedField": "title",
+      "matchedPhrases": [
+        "<span class=\"highlight\">Data</span> security and <span class=\"highlight\">data</span> processing"
+      ]
+    }
+  ]
+}
+```
+
+In this case, we found matches in the 'citation' and 'title' fields. The HTML included in the 'matchedPhrases' subfield
+is for display purposes. If you plan to display the TIMDEX data in a user interface, you can write a CSS rule on the
+'highlight' class to emphasize the text however you choose.
+
+While the example above shows the entire fields, 'matchedPhrases' has a character limit. If the field contains more
+than 100 characters, TIMDEX will return a 100-character fragment that contains the highlighted term.
+
+## See also
+
+- [Returning specific fields](returning_fields)

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -1,0 +1,10 @@
+---
+layout: home
+title: How-to guides
+has_children: true
+nav_order: 1
+---
+
+## How-to guides
+
+This section focuses on providing examples on how to solve specific problems.

--- a/docs/guides/retrieving_records.md
+++ b/docs/guides/retrieving_records.md
@@ -1,0 +1,55 @@
+---
+layout: home
+title: Retrieving a single record
+parent: How-to guides
+nav_order: 3
+---
+
+## Retrieving a single record
+
+
+In addition to searching, it is also possible to retrieve a specific record. To do so, you will need the
+`timdexRecordId` for the item. You can find this by returning that field in a query, like so:
+
+```graphql
+{
+  search(searchterm: "pragmatic programmer") {
+    records {
+      title
+      timdexRecordId
+    }
+  }
+}
+
+```
+
+[Run this query in the GraphQL playground.](https://timdex.mit.edu/playground?query=%7B%0A%20%20search(searchterm%3A%20%22pragmatic%20programmer%22)%20%7B%0A%20%20%20%20records%20%7B%0A%20%20%20%20%20%20title%0A%20%20%20%20%20%20timdexRecordId%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A)
+
+Once you have the `timdexRecordId` of the record in question, you can retrieve information about that record only:
+
+```graphql
+{
+  recordId(id: "alma:9935059777706761") {
+    title
+    edition
+    citation
+    holdings {
+      location
+    }
+    identifiers {
+      kind
+      value
+    }
+  }
+}
+```
+
+[Run this query in the GraphQL playground.](https://timdex.mit.edu/playground?query=%7B%0A%20%20recordId(id%3A%20%22alma%3A9935059777706761%22)%20%7B%0A%20%20%20%20title%0A%20%20%20%20edition%0A%20%20%20%20citation%0A%20%20%20%20holdings%20%7B%0A%20%20%20%20%20%20location%0A%20%20%20%20%7D%0A%20%20%20%20identifiers%20%7B%0A%20%20%20%20%20%20kind%0A%20%20%20%20%20%20value%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D)
+
+These are just a few of the fields that you can query on a record. Check out the [reference docs for the `Record` type
+for a full list](https://mitlibraries.github.io/timdex/reference/#definition-Record). Note that all of these fields can
+also be requested in the `records` field of the `Search` type.
+
+### See also
+- [Searching specific fields](searching_fields)
+- [Returning specific fields](returning_fields)

--- a/docs/guides/returning_fields.md
+++ b/docs/guides/returning_fields.md
@@ -1,0 +1,39 @@
+---
+layout: home
+title: Returning fields in GraphQL
+parent: How-to guides
+nav_order: 4
+---
+
+## Returning specific fields
+
+One of GraphQL's unique features is how it returns fields in query results. When you make a GraphQL query, it does not
+return all of the available fields in the results; instead, you include in the query the specific fields you want to
+return. This can make it easier to get only the data you're interested in.
+
+For example, in the query below, we are returning the `title` and `contributors` field. `Contributors` is returned a
+little differently because it's a nested field, also known as a multivalue field. Here we're requesting the `value`,
+but we could also return, for example, the `kind` subfield to see the type of contributor (author, editor, etc).
+
+```graphql
+{
+  search(searchterm: "afrofuturism") {
+    records {
+      title
+      contributors {
+        value
+      }
+    }
+  }
+}
+```
+
+[Run this query in the GraphQL playground.](https://timdex.mit.edu/playground?query=%7B%0A%20%20search(searchterm%3A%20%22afrofuturism%22)%20%7B%0A%20%20%20%20records%20%7B%0A%20%20%20%20%20%20title%0A%20%20%20%20%20%20contributors%20%7B%0A%20%20%20%20%20%20%20%20value%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D)
+
+Note that you can see in the [GraphQL playground](https://timdex.mit.edu/playground) shows which fields are nested and
+what their subfields are. This is also documented in our [API reference](https://mitlibraries.github.io/timdex/reference).
+
+### See also
+
+- [Keyword searching](searching_keywords)
+- [Searching specific fields](searching_fields)

--- a/docs/guides/searching_fields.md
+++ b/docs/guides/searching_fields.md
@@ -1,0 +1,55 @@
+---
+layout: home
+title: Targeting specific fields with your search
+parent: How-to guides
+nav_order: 2
+---
+
+## Targeting specific fields with your search
+
+In addition to [keyword searches](searching_keywords), it is possible to search a specific field. Try using the query
+below in our [GraphQL playground](https://timdex.mit.edu/playground):
+
+
+```graphql
+{
+  search(title: "Indigenous art") {
+    records {
+      title
+      contributors {
+        value
+      }
+    }
+  }
+}
+```
+
+This query will search for records with "Indigenous art" in the title and return the `title` and `contributor` fields
+of the matching results. (Note that the multivalue `contributors` field is returned differently than `title`. Check our
+guide on [returning fields](returning_fields_in_graphql) for more information on this.)
+
+
+You can also query multiple fields in the same search:
+
+```graphql
+{
+  search(title: "Indigenous art", subjects: "architecture") {
+    records {
+      title
+      contributors {
+        value
+      }
+    }
+  }
+}
+```
+
+[Run this query in the GraphQL playground.](https://timdex.mit.edu/playground?query=%7B%0A%20%20search(title%3A%20%22Indigenous%20art%22%2C%20subjects%3A%20%22architecture%22)%20%7B%0A%20%20%20%20records%20%7B%0A%20%20%20%20%20%20title%0A%20%20%20%20%20%20contributors%20%7B%0A%20%20%20%20%20%20%20%20value%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D)
+
+This query is similar to the first, except our results will include only records with 'Indigenous art' in the `title`
+field and 'architecture' in the `subjects` field.
+
+### See also
+
+- [Keyword searching](searching_keywords)
+- [Returning specific fields](returning_fields)

--- a/docs/guides/searching_keywords.md
+++ b/docs/guides/searching_keywords.md
@@ -1,0 +1,38 @@
+---
+layout: home
+title: Keyword searching
+parent: How-to guides
+nav_order: 1
+---
+
+## Keyword searching
+
+To search via keyword, provide a value to the `searchterm`, such as `searchterm: "my amazing keyword search"`.
+
+GraphQL requires you to specify which fields to return. In this example, we'll request the `title`, `source`,
+`sourceLink`, and `summary` fields.
+
+Our [GraphQL Playground](https://timdex.mit.edu/playground) provides documentation on the fields, and will make
+suggestions and inform you of syntax errors as you write your queries. Because of this, it is often a useful place to
+develop queries prior to copying them into any scripts or applications you are writing.
+
+```graphql
+{
+  search(searchterm: "orbital velocity") {
+    records {
+      title
+      source
+      sourceLink
+      summary
+    }
+  }
+}
+```
+
+[Run this query in the GraphQL playground.](https://timdex.mit.edu/playground?query=%7B%0A%20%20search(searchterm%3A%20%22orbital%20velocity%22)%20%7B%0A%20%20%20%20records%20%7B%0A%20%20%20%20%20%20title%0A%20%20%20%20%20%20source%0A%20%20%20%20%20%20sourceLink%0A%20%20%20%20%20%20summary%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D)
+
+### See also
+
+- [Limiting your search to specified sources](using_filters)
+- [Returning fields in GraphQL](returning_fields)
+- [Retrieving a single record](retrieving_records)

--- a/docs/guides/using_filters.md
+++ b/docs/guides/using_filters.md
@@ -1,0 +1,35 @@
+---
+layout: home
+title: Using filters to narrow your search
+parent: How-to guides
+nav_order: 5
+---
+
+## Using filters to narrow your search
+
+TIMDEX includes a set of filters that you can use to limit your search. The [API reference](https://mitlibraries.github.io/timdex/reference/#query-search)
+for the search operation lists each available filter and how to use them. In this how-guide, we'll look at the
+sourceFilter, but the process is similar with other filters. If you're not sure what values a filter will accept, try
+a search that [returns aggregations](viewing_aggregations).
+
+This example demonstrates a query that searches for the term "data" in the "dspace@mit" or the "abdul latif jameel
+poverty action lab dataverse" sources. We are requesting the fields `source`, `sourceLink` and `title`, which will be
+returned for each found record.
+
+```graphql
+{
+  search(searchterm: "data", sourceFilter: ["dspace@mit", "mit alma"]) {
+    records {
+      source
+      sourceLink
+      title
+    }
+  }
+}
+```
+
+https://timdex.mit.edu/playground?query=%7B%0A%20%20search(searchterm%3A%20%22data%22%2C%20sourceFilter%3A%20%5B%22dspace%40mit%22%2C%20%22mit%20alma%22%5D)%20%7B%0A%20%20%20%20records%20%7B%0A%20%20%20%20%20%20source%0A%20%20%20%20%20%20sourceLink%0A%20%20%20%20%20%20title%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D
+
+## See also
+
+- [Viewing search aggregations](viewing_aggregations)

--- a/docs/guides/viewing_aggregations.md
+++ b/docs/guides/viewing_aggregations.md
@@ -1,0 +1,43 @@
+---
+layout: home
+title: Viewing aggregations
+parent: How-to guides
+nav_order: 6
+---
+
+## Viewing search aggregations
+
+Aggregations list the total count of search results meeting a certain criterion. For example, you may want to know how
+many results of a query are in a certain language; aggregations will provide this data as part of the results.
+
+You can review [our reference documentation for the Aggregations type](../reference/#definition-Aggregations) to see all
+aggregations provided by TIMDEX. In the example below, we will use the `source` aggregation to see how records matching
+the search term "modal jazz" are distributed across sources.
+
+
+```graphql
+{
+  search(searchterm: "modal jazz") {
+    records {
+      source
+      sourceLink
+      title
+    }
+    aggregations {
+      source {
+        docCount
+        key
+      }
+    }
+  }
+}
+```
+
+[Run this query in the GraphQL playground.](https://timdex.mit.edu/playground?query=%7B%0A%20%20search(searchterm%3A%20%22modal%20jazz%22)%20%7B%0A%20%20%20%20records%20%7B%0A%20%20%20%20%20%20source%0A%20%20%20%20%20%20sourceLink%0A%20%20%20%20%20%20title%0A%20%20%20%20%7D%0A%20%20%20%20aggregations%20%7B%0A%20%20%20%20%20%20source%20%7B%0A%20%20%20%20%20%20%20%20docCount%0A%20%20%20%20%20%20%20%20key%0A%20%20%20%20%20%20%7D%0A%20%20%09%7D%0A%20%20%7D%0A%7D)
+
+
+Note that all aggregations are multivalue fields that require the `docCount` and `key` subfields.
+
+## See also
+
+- [Using filters to narrow your search](using_filters)


### PR DESCRIPTION
#### Why these changes are being introduced:

Version 2 of the API introduces significant changes that should be documented publicly for our end users.

#### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/TIMX-192

#### How this addresses that need:

This adds an initial set of how-to guides, which provide specific example queries of certain features.

#### Side effects of this change:

* There are some WAVE errors, primarily related to low contrast.
We might want to use the light color scheme when we launch.
* Since this is not considered an external link like the
SpectaQL-generated reference docs, it seems to always appear in
the nav bar above reference, no matter how the nav order is set.
This is probably fine, but if I were developing an app with TIMDEX,
the reference docs are probably what I would look up most frequently
(although maybe not first).

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
