### PR TITLE
Provide message when record not found

### DIFF
--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -38,7 +38,7 @@ module Types
       def record_id(id:, index:)
         result = Retrieve.new.fetch(id, Timdex::OSClient, index)
         result['hits']['hits'].first['_source']
-      rescue Elasticsearch::Transport::Transport::Errors::NotFound
+      rescue OpenSearch::Transport::Transport::Errors::NotFound
         raise GraphQL::ExecutionError, "Record '#{id}' not found"
       end
 

--- a/test/controllers/graphql_controller_v2_test.rb
+++ b/test/controllers/graphql_controller_v2_test.rb
@@ -331,6 +331,22 @@ class GraphqlControllerV2Test < ActionDispatch::IntegrationTest
     end
   end
 
+    test 'graphqlv2 retrieve with not found recordid' do
+    VCR.use_cassette('graphql v2 retrieve not found') do
+      post '/graphql', params: { query: '{
+                                  recordId(id: "totallylegitrecordid") {
+                                    timdexRecordId
+                                    title
+                                  }
+                                }' }
+      assert_equal(200, response.status)
+      json = JSON.parse(response.body)
+      assert_nil(json['data'])
+      assert_equal("Record 'totallylegitrecordid' not found", json['errors'].first['message'])
+    end
+  end
+
+
   test 'graphqlv2 holding location is not required' do
     VCR.use_cassette('graphql v2 location') do
       post '/graphql', params: { query: '{

--- a/test/vcr_cassettes/graphql_v2_retrieve_not_found.yml
+++ b/test/vcr_cassettes/graphql_v2_retrieve_not_found.yml
@@ -1,0 +1,76 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:9200/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - 'opensearch-ruby/2.1.0 (RUBY_VERSION: 3.1.2; darwin x86_64; Faraday v2.7.4)'
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '347'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "name" : "abb77df940c2",
+          "cluster_name" : "docker-cluster",
+          "cluster_uuid" : "c-VRJvUhQEC0sXa8uIdOQw",
+          "version" : {
+            "distribution" : "opensearch",
+            "number" : "2.3.0",
+            "build_type" : "tar",
+            "build_hash" : "6f6e84ebc54af31a976f53af36a5c69d474a5140",
+            "build_date" : "2022-09-09T00:07:12.137133581Z",
+            "build_snapshot" : false,
+            "lucene_version" : "9.3.0",
+            "minimum_wire_compatibility_version" : "7.10.0",
+            "minimum_index_compatibility_version" : "7.0.0"
+          },
+          "tagline" : "The OpenSearch Project: https://opensearch.org/"
+        }
+  recorded_at: Wed, 15 Mar 2023 15:20:12 GMT
+- request:
+    method: post
+    uri: http://localhost:9200/timdex-prod/_search
+    body:
+      encoding: UTF-8
+      string: '{"query":{"ids":{"values":["totallylegitrecordid"]}}}'
+    headers:
+      User-Agent:
+      - 'opensearch-ruby/2.1.0 (RUBY_VERSION: 3.1.2; darwin x86_64; Faraday v2.7.4)'
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '142'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"took":47,"timed_out":false,"_shards":{"total":1,"successful":1,"skipped":0,"failed":0},"hits":{"total":{"value":0,"relation":"eq"},"max_score":null,"hits":[]}}'
+  recorded_at: Wed, 15 Mar 2023 15:20:12 GMT
+recorded_with: VCR 6.1.0


### PR DESCRIPTION
You can view the effects by comparing this PR

https://timdex-pr-676.herokuapp.com/playground?query=%7B%0A%20%20recordId(id%3A%22hallo%22)%20%7B%0A%20%20%20%20timdexRecordId%0A%20%20%7D%0A%7D

with the same query in production

https://timdex.mit.edu/playground?query=%7B%0A%20%20recordId(id%3A%22hallo%22)%20%7B%0A%20%20%20%20timdexRecordId%0A%20%20%7D%0A%7D

Why are these changes being introduced:

* when a recordId query was run but no record was found, the application through a 500 error
* expected behavior would be to return a message to the user that the record they requested was not found

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/TIMX-197

How does this address that need:

* This fixes a copy/paste error where we were looking for an ElasticSearch Not Found error rather than an OpenSearch Not Found error in the GraphQL for v2 logic

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
