### PR TITLE
Link to V2 dev docs from splash page

### DIFF
--- a/app/views/static/index.html.erb
+++ b/app/views/static/index.html.erb
@@ -9,7 +9,10 @@
 
       <p>We currently provide searching of records in MIT Libraries catalog, DSpace@MIT, and MIT ArchivesSpace.</p>
 
-      <p>Access is via a <a href="https://graphql.org">GraphQL</a> endpoint by posting to <%= link_to(graphql_url) %>. We recommend starting by exploring our <a href="/playground">interactive GraphQL playground.</a> It's neat, check it out!.</p>
+      <p>Access is via a <a href="https://graphql.org">GraphQL</a> endpoint by posting to <%= link_to(graphql_url) %>.
+        We recommend starting by exploring our <a href="/playground">interactive GraphQL playground.</a>, or you can
+        look through our <a href="https://mitlibraries.github.io/timdex/">developer documentation</a> for how-to guides,
+        API reference, and more.
 
       <div class="well">
         <p>Example query to use in the playground or your own app:</p>
@@ -33,7 +36,7 @@
 
       <h3>REST API deprecated</h3>
 
-      <p><strong>Our deprecated REST API <a href="https://mitlibraries.github.io/timdex/">documentation</a> is still available, but the REST endpoint will be going away entirely very soon (early 2023) and we highly recommend moving to GraphQL. If you need help migrating from REST to GraphQL please <a href="mailto:timdex@mit.edu?Subject=TIMDEX%20GraphQL%20transition">let us know</a></strong></p>
+      <p><strong>Our deprecated REST API <a href="https://mitlibraries.github.io/timdex/deprecated_rest/">documentation</a> is still available, but the REST endpoint will be going away entirely very soon (early 2023) and we highly recommend moving to GraphQL. If you need help migrating from REST to GraphQL please <a href="mailto:timdex@mit.edu?Subject=TIMDEX%20GraphQL%20transition">let us know</a></strong></p>
 
       <p>Feedback is welcome via <a href="mailto:timdex@mit.edu?Subject=TIMDEX%20Feedback">timdex@mit.edu</a>.
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,31 +2,30 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_12_134246) do
-
+ActiveRecord::Schema[7.0].define(version: 2018_10_12_134246) do
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
-    t.datetime "reset_password_sent_at"
-    t.datetime "remember_created_at"
+    t.datetime "reset_password_sent_at", precision: nil
+    t.datetime "remember_created_at", precision: nil
     t.string "confirmation_token"
-    t.datetime "confirmed_at"
-    t.datetime "confirmation_sent_at"
+    t.datetime "confirmed_at", precision: nil
+    t.datetime "confirmation_sent_at", precision: nil
     t.string "unconfirmed_email"
     t.integer "failed_attempts", default: 0, null: false
     t.string "unlock_token"
-    t.datetime "locked_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "locked_at", precision: nil
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,30 +2,31 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `bin/rails
-# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
-# be faster and is potentially less error prone than running all of your
-# migrations from scratch. Old migrations may fail to apply correctly if those
-# migrations use external dependencies or application code.
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2018_10_12_134246) do
+ActiveRecord::Schema.define(version: 2018_10_12_134246) do
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
-    t.datetime "reset_password_sent_at", precision: nil
-    t.datetime "remember_created_at", precision: nil
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
     t.string "confirmation_token"
-    t.datetime "confirmed_at", precision: nil
-    t.datetime "confirmation_sent_at", precision: nil
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
     t.string "unconfirmed_email"
     t.integer "failed_attempts", default: 0, null: false
     t.string "unlock_token"
-    t.datetime "locked_at", precision: nil
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "locked_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
#### Why these changes are being introduced:

There is no clear path to the V2 docs from our splash page.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/TIMX-209

#### How this addresses that need:

This adds a link to the V2 dev docs on the splash page.

#### Side effects of this change:

The link in the deprecated docs paragraph now goes to the V2 docs, so I updated that to go to the deprecated docs page.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
