### PR TITLE
Fix missed merge conflict

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,9 +11,6 @@ gem 'graphql'
 gem 'jwt'
 gem 'lograge'
 gem 'mitlibraries-theme', git: 'https://github.com/mitlibraries/mitlibraries-theme', tag: 'v1.0.2'
-gem 'net-imap', require: false
-gem 'net-pop', require: false
-gem 'net-smtp', require: false
 gem 'opensearch-ruby'
 gem 'puma'
 gem 'rack-attack'


### PR DESCRIPTION
I had removed these gems from Gemfile since they were only explicitly needed for older versions of Rails with newer versions of Ruby. Now that we are on new Rails, they were not needed. However, a dependency update landed in main before I merged this change and I failed to manage the merge conflict appropriately. This resolves the problem I introduced.

#### Developer

- [ ] All new ENV is documented in README
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

YES
