### PR TITLE
Fix techdocs build

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -33,7 +33,7 @@ jobs:
         run: npm install -g spectaql@v2
       - name: Build reference docs
         run: |
-          spectaql --introspection-url https://timdex-api-prod-v2.herokuapp.com/graphql -e -t ./docs/reference docs/reference/_spectaql_config.yml
+          spectaql --introspection-url https://timdex.mit.edu/graphql -e -t ./docs/reference docs/reference/_spectaql_config.yml
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@v1
         with:


### PR DESCRIPTION
NOTE: this can't be tested until merged due to the action only being allowed to run from the main branch.

Why are these changes being introduced:

* The build process used a v2 server we retired

Relevant ticket(s):

* N/A

How does this address that need:

* Updates the build process to use the production server

#### Developer

- [ ] All new ENV is documented in README
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
