### PR TITLE
Update baseurl to include project name

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -11,7 +11,7 @@ color_scheme: dark
 exclude:
   - architecture-decisions
 
-baseurl: ""
+baseurl: "/timdex"
 # Enable or disable the site search
 # Supports true (default) or false
 search_enabled: true

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ This documentation site provides tutorials, guides, reference documentation, and
 
 If you have any questions, please reach out via timdex@mit.edu!
 
-![TIMDEX mascot: a variant of the MIT mascot with the words TIMDEX in a speech bubble!](/assets/images/timdex-beaver.png)
+![TIMDEX mascot: a variant of the MIT mascot with the words TIMDEX in a speech bubble!](/timdex/assets/images/timdex-beaver.png)
 
 ## REST API retired
 


### PR DESCRIPTION
This should resolve the issue in our built documentation. It isn't clear why it worked before. If this does work, I'll update documentation on how to build docs locally as this changes that slightly.

Our current process requires merging for the GitHub Pages to build fully to confirm if this works or not (yes this sucks).