### PR TITLE
Update documentation on building docs locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,9 @@ to ensure everything looks as expected.
 bundle exec jekyll serve --incremental --source ./docs
 ```
 
-Once the jekyll server is running, you can access the local docs at http://localhost:4000
+Once the jekyll server is running, you can access the local docs at http://localhost:4000/timdex/
+
+Note: it is important to load the documentation from the `/timdex/` path locally as that is how it works when built and deployed to GitHub Pages so testing locally the same way will ensure our asset paths will work when deployed.
 
 ### Automatic generation of technical specifications from GraphQL
 


### PR DESCRIPTION
Note: please also review https://github.com/MITLibraries/timdex/pull/726 and https://github.com/MITLibraries/timdex/pull/727 which were merged without review to resolve an issue building and deploying the documentation to GitHub Pages.

Why are these changes being introduced:

* Our deployed documentation ran into issues that required a config change that requires us to change how we load the docs locally

How does this address that need:

* documents how and why to access the documentations using `/timdex/` as part of the URL path

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
