### PR TITLE
Adds geo_distance query to opensearch

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,4 +1,5 @@
 plugins:
   rubocop:
     enabled: true
-    channel: rubocop-1-23-0
+    channel: rubocop-1-56-3
+

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.1
   NewCops: enable
   Exclude:
     - "db/**/*"


### PR DESCRIPTION
This has not yet been integrated with GraphQL, so the best way to validate this work is to use the rails console.

```ruby
bin/rails console
q = {geopoint:{distance: "1mi", latitude: "45", longitude: "-112"}}
Opensearch.new.search(0, q, Timdex::OSClient)
```

You can also combine keyword (or filters) using our existing query syntax:

```
q = {geopoint:{distance: "1mi", latitude: "45", longitude: "-112"}, searchterm: "train stations"}
```

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/GDT-135

How does this address that need:

* Adds an optional geo_distance search to our existing opensearch query builder

Document any side effects to this change:

* rubocop config has been updated to the current version of ruby we are using
* many opensearch tests were updated as the previous versions continued to pass even if I changed the expected values

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
