### PR TITLE
Updates format to be a single string

### DIFF
--- a/app/graphql/types/record_type.rb
+++ b/app/graphql/types/record_type.rb
@@ -163,7 +163,7 @@ module Types
     field :contents, [String], null: true, description: 'Table of contents for item'
     field :summary, [String], null: true,
                               description: 'Summary of contents of item (also where abstract goes if applicable)'
-    field :format, [String], null: true, description: 'Format of item e.g. "Print Volume", "DVD", etc.'
+    field :format, String, null: true, description: 'Format of item e.g. "Print Volume", "DVD", etc.'
     field :literary_form, String, null: true, description: 'Identifies the item as fiction or nonfiction'
     field :related_place, [String], null: true, deprecation_reason: 'Use `locations`'
     field :in_bibliography, [String], null: true, deprecation_reason: 'Use `related_items`'


### PR DESCRIPTION
Why are these changes being introduced:

* This was a bug in the graphql spec. TIMDEX has always treated format as a single string

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/GDT-151

How does this address that need:

* Updates GraphQL spec to correct the expectation to be a single string

Document any side effects to this change:

* None of the TIMDEX sources mapped to anything other than a single string for `format`. Therefore, anyone requesting `format` via GraphQL would be getting an error in production at this time. This resolves that problem, so a deprecation does not feel appropriate. This was a bug that caused the inability to use a field, not a change in how a previously usable field is being mapped.
* Even though the previous comment remains true, we'll still need to refresh the spec in our deployed timdex ui instances as the spec has indeed changed.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
