### PR TITLE
Adds opensearch geo_bounding_box query support

### DIFF
--- a/app/models/opensearch.rb
+++ b/app/models/opensearch.rb
@@ -111,9 +111,34 @@ class Opensearch
     match_single_field_nested(:subjects, m)
 
     match_geodistance(m) if @params[:geodistance].present?
+    match_geobox(m) if @params[:geobox].present?
     m
   end
 
+  # https://opensearch.org/docs/latest/query-dsl/geo-and-xy/geo-bounding-box/
+  def match_geobox(match_array)
+    match_array << {
+      bool: {
+        must: {
+          match_all: {}
+        },
+        filter: {
+          geo_bounding_box: {
+            'locations.geoshape': {
+              top: @params[:geobox][:max_latitude],
+              bottom: @params[:geobox][:min_latitude],
+              left: @params[:geobox][:min_longitude],
+              right: @params[:geobox][:max_longitude]
+            }
+          }
+        }
+      }
+    }
+  end
+
+  # https://www.elastic.co/guide/en/elasticsearch/reference/7.17/query-dsl-geo-distance-query.html
+  # Note: at the time of this implementation, opensearch does not have documentation on
+  # this features hence the link to the prefork elasticsearch docs
   def match_geodistance(match_array)
     match_array << {
       bool: {


### PR DESCRIPTION
This has not yet been integrated with GraphQL, so the best way to validate this work is to use the rails console. To test locally, you'll need an opensearch instance running with appropriate data loaded.

```ruby
bin/rails console

q = {geobox: {max_latitude: "42.886",
              min_latitude: "41.239",
              max_longitude: "-73.928",
              min_longitude: "-69.507"}}

Opensearch.new.search(0, q, Timdex::OSClient)
```

You can also combine keyword (or filters) using our existing query syntax:

```ruby
q = {geobox: {max_latitude: "42.886",
              min_latitude: "41.239",
              max_longitude: "-73.928",
              min_longitude: "-69.507"},
       q: "rail stations"}

Opensearch.new.search(0, q, Timdex::OSClient)
```

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/GDT-167

How does this address that need:

* Adds an optional geo_bounding_box search to our existing opensearch query builder

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
