### PR TITLE
Add publishers field to record type

### DIFF
--- a/app/graphql/types/record_type.rb
+++ b/app/graphql/types/record_type.rb
@@ -131,6 +131,12 @@ module Types
     end
   end
 
+  class PublishersType < Types::BaseObject
+    field :name, String, description: 'The name of the publisher'
+    field :date, String, description: 'The date of the publication'
+    field :location, String, description: 'Where the publisher is located'
+  end
+
   class RecordType < Types::BaseObject
     field :identifier, ID, null: false, deprecation_reason: 'Use `timdex_record_id`'
     field :timdex_record_id, ID, null: false, description: 'TIMDEX unique identifier for the item'
@@ -158,8 +164,8 @@ module Types
     field :call_numbers, [String], null: true, description: 'Identification number used to classify and locate item'
     field :citation, String, null: true, description: 'Citation for item'
     field :edition, String, null: true, description: 'Edition information for item'
-    field :imprint, [String], null: true, deprecation_reason: 'Use `publicationInformation`'
-    field :publication_information, [String], description: 'Imprint information for item'
+    field :imprint, [String], null: true, deprecation_reason: 'Use `publishers`'
+    field :publication_information, [String], deprecation_reason: 'Use `publishers`'
     field :physical_description, String, null: true, description: 'Physical description of item'
     field :publication_frequency, [String], null: true,
                                             description: 'Publication frequency of item (used for serials)'
@@ -188,6 +194,7 @@ module Types
     field :provider, String,
           null: true,
           description: 'The host institution for a resource. Currently only used for geospatial records'
+    field :publishers, [Types::PublishersType], null: true, description: 'Publishers that are associated with the item'
 
     def in_bibliography
       @object['related_items']&.map { |i| i['uri'] if i['relationship'] == 'IsCitedBy' }&.compact
@@ -203,6 +210,10 @@ module Types
 
     def publication_date
       @object['dates']&.map { |date| date['value'] if date['kind'] == 'Publication date' }&.compact&.first
+    end
+
+    def publication_information
+      @object['publishers']&.map { |publisher| publisher.values.join('; ') }
     end
 
     def file_formats


### PR DESCRIPTION
#### Why these changes are being introduced:

We recently [made the decision in transmogrifier](https://github.com/MITLibraries/transmogrifier/pull/132) To map publication information to a new nested field, named `publishers` to avoid a naming conflict with the existing `publicationInformation` field.

#### Relevant ticket(s):

* [GDT-270](https://mitlibraries.atlassian.net/browse/GDT-270)
* [GDT-218](https://mitlibraries.atlassian.net/browse/GDT-218)
* [GDT-229](https://mitlibraries.atlassian.net/browse/GDT-229)
* [GDT-271](https://mitlibraries.atlassian.net/browse/GDT-271)

#### How this addresses that need:

This adds the new `publishers` field and deprecates `publicationInformation`.

#### Side effects of this change:

A follow-on ticket is needed to add this field to the UI. (This is ticketed as GDT-271.)

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO


[GDT-270]: https://mitlibraries.atlassian.net/browse/GDT-270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GDT-218]: https://mitlibraries.atlassian.net/browse/GDT-218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GDT-229]: https://mitlibraries.atlassian.net/browse/GDT-229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GDT-271]: https://mitlibraries.atlassian.net/browse/GDT-271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ