### PR TITLE
Pin CDN version of GraphiQL to 3.x

### DIFF
--- a/public/playground.html
+++ b/public/playground.html
@@ -52,12 +52,12 @@
       copy them directly into your environment, or perhaps include them in your
       favored resource bundler.
      -->
-    <link rel="stylesheet" href="https://unpkg.com/graphiql/graphiql.min.css" />
+    <link rel="stylesheet" href="https://unpkg.com/graphiql@3/graphiql.min.css" />
   </head>
 
   <body>
     <div id="graphiql">Loading...</div>
-    <script src="https://unpkg.com/graphiql/graphiql.min.js" type="application/javascript"></script>
+    <script src="https://unpkg.com/graphiql@3/graphiql.min.js" type="application/javascript"></script>
     <script>
       /**
        * This GraphiQL example illustrates how to use some of GraphiQL's props


### PR DESCRIPTION
To test:

Confirm playground works in this PR build.

Compare to playground not working in production TIMDEX.


4.x recently was released and breaks our example.

I'll open a ticket to upgrade to 4, but it was not going to be quick so this will be a stop gap.

#### Developer

- [ ] All new ENV is documented in README
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Requires database migrations?

YES | NO

#### Includes new or updated dependencies?

YES | NO
