### PR TITLE
Add safe navigation to file_formats method

### DIFF
--- a/app/graphql/types/record_type.rb
+++ b/app/graphql/types/record_type.rb
@@ -217,7 +217,7 @@ module Types
     end
 
     def file_formats
-      @object['file_formats'].uniq
+      @object['file_formats']&.uniq
     end
 
     def imprint

--- a/test/graphql/types/record_type_test.rb
+++ b/test/graphql/types/record_type_test.rb
@@ -1,0 +1,33 @@
+require 'test_helper'
+
+class RecordTypeTest < ActiveSupport::TestCase
+  # Test that file_formats handles missing key gracefully
+  test 'file_formats returns nil when file_formats key is missing' do
+    record_data = { 'title' => 'Test Record' }
+    record_type = Types::RecordType.send(:new, record_data, {})
+
+    result = record_type.file_formats
+    assert_nil result, 'file_formats should return nil when key is missing'
+  end
+
+  # Test that file_formats handles explicit nil gracefully
+  test 'file_formats returns nil when file_formats is nil' do
+    record_data = { 'title' => 'Test Record', 'file_formats' => nil }
+    record_type = Types::RecordType.send(:new, record_data, {})
+
+    result = record_type.file_formats
+    assert_nil result, 'file_formats should return nil when value is nil'
+  end
+
+  # Test that file_formats works correctly when data is present
+  test 'file_formats returns unique formats when present' do
+    record_data = {
+      'title' => 'Test Record',
+      'file_formats' => %w[PDF PDF EPUB PDF]
+    }
+    record_type = Types::RecordType.send(:new, record_data, {})
+
+    result = record_type.file_formats
+    assert_equal %w[PDF EPUB], result, 'file_formats should return unique values'
+  end
+end


### PR DESCRIPTION
#### Why these changes are being introduced:

We are calling `uniq` on `file_formats`, which
returns a nil error if that field does not exist.

#### Relevant ticket(s):

- [TIMX-628](https://mitlibraries.atlassian.net/browse/TIMX-628)

#### How this addresses that need:

This adds a safe navigation operator to the
`file_formats` method.

#### Side effects of this change:

I added a regression test, which creates a new
test file. It feels a bit odd not to test the
other Record Type methods in there, but doing so
seemed far out of scope of this ticket.

#### Developer

- [ ] All new ENV is documented in README
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO


[TIMX-628]: https://mitlibraries.atlassian.net/browse/TIMX-628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ